### PR TITLE
docs:m1-01 建立 video-web 文档与仓库治理骨架

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md（video-web）
+
+## 目标与边界
+- video-web 仅作为**独立前端仓库**运行，不承载 API 路由、后台任务执行和静态托管职责。
+- 前端与后端通过 `VITE_API_BASE_URL` 与 `/api/*` 路径通信；跨仓联调只在运行文档中定义端口与鉴权配置。
+- 功能以 MVP 为主：落地页 → 授权登录 → 工作台任务列表 → 任务详情/下载。
+
+## 开发原则
+- 采用测试优先（Red → Green → Refactor）。任何可验证行为应先有失败测试，再补最小实现。
+- 使用 TDD 的测试标签约定提交：`test:m1-*`、`impl:m1-*`、`docs:m1-*`、`feat:m1-*`、`chore:m1-*`（`m1` 为本轮起始编号）。
+- 采用 TypeScript 严格边界思路：最小接口、清晰职责、避免一次性大文件。
+- 遵循「能跑就行」到「能测」再到「好看」，优先保证交付闭环而非炫技。
+
+## 路由与状态
+- 路由约定：
+  - `/` 落地页（无需鉴权）
+  - `/auth` 登录页（OAuth 回跳后入参 `token`）
+  - `/workbench` 工作台（必须鉴权）
+  - `/tasks/:taskId` 任务详情（必须鉴权）
+- 鉴权状态由 `AppProvider` 持久化 token 到 `localStorage.video_web_access_token`。
+- 所有请求层统一通过 `src/lib/api.ts` 和 `query` hooks / 手工 mutations。
+
+## TDD 与测试门禁
+- 新文件应优先新增最小单元测试覆盖：鉴权守卫、解析表单、任务列表、状态按钮。
+- 前端 CI 理想最小门禁：
+  - `npm run lint`
+  - `npm run test`
+  - `npm run test:e2e`
+- 每个 issue 的实现结尾必须有验收证据（至少一次命令输出和关键日志）。
+
+## 文档规范
+- `docs/` 需按长期影响分类（PRD/plan/design/acceptance/operations）。
+- 临时调试与一次性记事不要写进 docs；应放测试脚本、Issue、PR 讨论和分支提交里。
+- 每个正式文档文件应包含明确的目标、边界、验收标准和剩余风险。
+
+## 提交与交付
+- 使用中文提交摘要，格式建议：
+  - `impl:m1-xx xxx`
+  - `test:m1-xx xxx`
+  - `docs:m1-xx xxx`
+  - `feat:m1-xx xxx`
+  - `chore:m1-xx xxx`
+- 交付说明按「做了什么 / 怎么验证 / 还存在哪些风险」三点输出。

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# 视频下载器前端（video-web）
+
+本仓库承接 API-First 视频下载器的前端交付，采用独立仓库 + React + TypeScript + React Router + TanStack Query 组织。
+
+## 一句话说明
+
+先在落地页完成链接解析，再通过授权后进入工作台进行任务管理，最后展示任务详情与下载链接。
+
+## 仓库结构
+
+- `src/`：前端源码
+- `public/`：静态资源
+- `docs/`：架构/计划/验收/运行文档
+- `tests/`：Playwright E2E 与单元测试入口
+- `package.json`：依赖与脚本
+
+## 运行方式
+
+```bash
+npm install
+cp .env.example .env
+npm run dev
+```
+
+默认访问 `http://localhost:5173`，后端默认 `http://localhost:8000/api`。
+
+## 主要脚本
+
+- `npm run dev`：启动开发服务
+- `npm run build`：类型校验 + 打包
+- `npm run lint`：ESLint
+- `npm run test`：Vitest 单元测试
+- `npm run test:e2e`：Playwright E2E（要求 `video-server` 可达）
+
+## 关键约定
+
+- 路由：`/`（落地页）`/auth`（登录/回跳处理）`/workbench`（任务列表）`/tasks/:taskId`（任务详情）
+- API 基址：`VITE_API_BASE_URL`，接口统一挂载在 `/api/*`
+- 鉴权：`localStorage.video_web_access_token`
+- 测试优先：新行为要先有可重放的失败测试，再进入实现
+
+## 文档入口
+
+- `docs/plans/`：执行计划与任务拆分
+- `docs/design/`：前后端交互与页面结构
+- `docs/acceptance/`：验收点与测试记录
+- `docs/operations/`：启动/联调/发布说明

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,36 @@
+---
+layer: operations
+doc_no: "DOCS-ROOT"
+audience:
+  - PM
+  - Dev
+  - QA
+purpose: "定义 video-web 文档目录、更新边界与长期维护方式。"
+canonical_path: "docs/README.md"
+status: draft
+version: "0.1.0"
+owner: "StephenQiu30"
+inputs:
+  - "issue 清单与执行需求"
+outputs:
+  - "按类型归档的文档索引"
+triggers:
+  - "新里程碑前置、执行计划变更、验收更新"
+downstream:
+  - "docs/plans"
+  - "docs/design"
+  - "docs/acceptance"
+  - "docs/operations"
+---
+
+# video-web Docs 根目录
+
+## 目录说明
+
+- `docs/plans/`：任务拆分、里程碑、执行顺序
+- `docs/design/`：前端架构、状态管理、交互组件约定
+- `docs/acceptance/`：验收标准、测试结果、残留风险
+- `docs/operations/`：联调、启动、发布、故障处理
+- `docs/superpowers/`：Superpowers 执行计划与复盘
+
+每个目录内必须附带 `README.md`，说明该目录放什么/不放什么。

--- a/docs/acceptance/01-mvp-acceptance-gates.md
+++ b/docs/acceptance/01-mvp-acceptance-gates.md
@@ -1,0 +1,54 @@
+---
+layer: acceptance
+doc_no: "ACPT-001"
+audience:
+  - QA
+  - Dev
+purpose: "定义 video-web MVP 验收门禁和测试证据挂载方式。"
+canonical_path: "docs/acceptance/01-mvp-acceptance-gates.md"
+status: draft
+version: "1.0.0"
+owner: "StephenQiu30"
+inputs:
+  - "docs/plans/05-mvp-task-micro-breakdown.md"
+outputs:
+  - "验收通过/阻塞证据"
+triggers:
+  - "阶段任务完成后"
+  - "PR 合入前"
+downstream:
+  - "docs/operations/01-runbook.md"
+---
+
+# MVP 验收门禁
+
+## 功能门禁
+
+- 未登录访问 `/workbench` 与 `/tasks/:id` 必须重定向到 `/auth`。
+- `/auth` 能写入 `token` 并回跳 `/workbench`。
+- 落地页可解析 URL，返回 format 列表并可创建下载任务。
+- 任务详情页可展示事件列表、取消、重试、下载按钮。
+
+## 测试门禁
+
+- `npm run test` 必须通过（至少包含 auth 守卫、解析表单、任务列表/详情关键行为）。
+- `npm run test:e2e` 至少包含登录路由、解析/创建到详情链路。
+- `npm run lint` 与 `npm run build` 无阻塞错误。
+
+## 证据记录
+
+- 每个阶段完成后在 issue 与本文件追加对应命令、时间和失败/通过摘要。
+
+### 2026-05-23 阶段一（TDD + 登录链路）
+
+- 时间：2026-05-23 11:24:16
+- 命令与结果：
+  - `npm run test` ✅ 通过（4/4）
+  - `npm run lint` ✅ 通过
+  - `npm run build` ✅ 通过
+  - `npm run test:e2e` ✅ 通过（2/2）
+- 覆盖范围：
+  - 未登录访问 `/workbench` 的重定向鉴权
+  - 鉴权回跳页 `/auth` 展示与 `token` 回跳
+  - 主页解析表单成功链路与任务创建参数
+  - E2E 登录链路（无 token 重定向 + token 回跳）

--- a/docs/acceptance/README.md
+++ b/docs/acceptance/README.md
@@ -1,0 +1,26 @@
+---
+layer: acceptance
+doc_no: "ACPT"
+audience:
+  - QA
+  - Dev
+purpose: "记录前端验收门禁、测试证据和风险。"
+canonical_path: "docs/acceptance/README.md"
+status: draft
+version: "0.1.0"
+owner: "StephenQiu30"
+inputs:
+  - "测试脚本和执行反馈"
+outputs:
+  - "可追溯验收记录"
+triggers:
+  - "关键任务完成"
+  - "回归测试执行"
+downstream:
+  - "docs/operations"
+---
+
+# acceptance 说明
+
+- 每次实现关键行为前需先有失败测试，再补绿。
+- 验收文件需包含执行命令与时间戳，未通过项需列明根因与下一步动作。

--- a/docs/design/01-frontend-runtime-design.md
+++ b/docs/design/01-frontend-runtime-design.md
@@ -1,0 +1,40 @@
+---
+layer: design
+doc_no: "DESIGN-001"
+audience:
+  - Dev
+purpose: "明确 video-web 运行时架构、鉴权流、任务流和 API 依赖边界。"
+canonical_path: "docs/design/01-frontend-runtime-design.md"
+status: draft
+version: "1.0.0"
+owner: "StephenQiu30"
+inputs:
+  - "video-server 接口契约"
+outputs:
+  - "数据流与组件边界定义"
+triggers:
+  - "API 字段变更"
+  - "路由结构变更"
+downstream:
+  - "docs/acceptance/01-mvp-acceptance-gates.md"
+---
+
+# 前端运行时设计
+
+## 数据流
+
+- `AuthContext` 保存 `token`，并持久化到 `localStorage`。
+- `src/lib/api.ts` 提供 request wrappers，统一在 header 中透传 `Authorization: Bearer <token>`。
+- 页面通过 `useQuery/useMutation` 进行任务读取与动作触发。
+
+## 页面关系
+
+- `HomePage`：输入 URL + parse + format 选择 + createTask
+- `AuthPage`：解析 `?token=` 并回落到工作台
+- `WorkbenchPage`：列任务 + 进入详情
+- `TaskDetailPage`：事件流 + 状态变化 + cancel/retry/download
+
+## 前后端边界
+
+- 鉴权、配额、下载签名均由后端返回。
+- 前端仅负责展示与用户操作，不做下载链接签名生成或任务执行决策。

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,27 @@
+---
+layer: design
+doc_no: "DESIGN"
+audience:
+  - Dev
+  - PM
+purpose: "定义前端架构、页面模块和与 video-server 的接口约束。"
+canonical_path: "docs/design/README.md"
+status: draft
+version: "0.1.0"
+owner: "StephenQiu30"
+inputs:
+  - "video-server API 契约"
+  - "页面交互需求"
+outputs:
+  - "页面流、状态流、数据模型决策"
+triggers:
+  - "接口字段变更"
+  - "核心页面重构"
+downstream:
+  - "docs/acceptance"
+---
+
+# design 说明
+
+- 仅存放架构与设计决策文档。
+- 约定前端从 `src/lib/api.ts` 与 `@tanstack/react-query` 统一发起 API。

--- a/docs/operations/01-runbook.md
+++ b/docs/operations/01-runbook.md
@@ -1,0 +1,53 @@
+---
+layer: operations
+doc_no: "OPS-001"
+audience:
+  - Dev
+  - QA
+purpose: "给出 video-web 的本地运行、联调与快速排障步骤。"
+canonical_path: "docs/operations/01-runbook.md"
+status: draft
+version: "1.0.0"
+owner: "StephenQiu30"
+inputs:
+  - "项目 README 与后端启动状态"
+outputs:
+  - "本地联调 check list"
+triggers:
+  - "首次联调"
+  - "端口/接口异常"
+downstream:
+  - "docs/acceptance/01-mvp-acceptance-gates.md"
+---
+
+# video-web 联调运行手册
+
+## 1. 初始化
+
+```bash
+npm install
+cp .env.example .env
+```
+
+## 2. 启动前端
+
+```bash
+npm run dev
+```
+
+默认访问 `http://localhost:5173`，后端要求 `VITE_API_BASE_URL` 可用（默认 `http://localhost:8000`）。
+
+## 3. 问题排查
+
+- 401：检查 `/api/auth/github/callback` 回跳 token 是否写入 `localStorage`.
+- 空列表：检查 `/api/tasks` 鉴权头与 `token` 是否有效。
+- 无法下载：确认任务状态已 `SUCCEEDED`，再调用 `/tasks/:id/download-link`。
+
+## 4. 证据命令
+
+```bash
+npm run lint
+npm run test
+npm run build
+npm run test:e2e
+```

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,26 @@
+---
+layer: operations
+doc_no: "OPS"
+audience:
+  - Dev
+  - QA
+purpose: "规范本地运行、联调、调试和故障恢复流程。"
+canonical_path: "docs/operations/README.md"
+status: draft
+version: "0.1.0"
+owner: "StephenQiu30"
+inputs:
+  - "运行环境与后端联调状态"
+outputs:
+  - "Runbook 与联调 check list"
+triggers:
+  - "联调失败"
+  - "本地环境漂移"
+downstream:
+  - "docs/acceptance"
+---
+
+# operations 说明
+
+- 记录前端本地运行与联调步骤。
+- 优先确保 dev server 与 video-server API 可达，问题先以 `operations` 文档更新，不在临时聊天中流失。

--- a/docs/plans/05-mvp-task-micro-breakdown.md
+++ b/docs/plans/05-mvp-task-micro-breakdown.md
@@ -1,0 +1,71 @@
+---
+layer: plans
+doc_no: "PLAN-005"
+audience:
+  - Dev
+  - QA
+  - PM
+purpose: "将 MVP 前端重构拆分为可执行的小任务，明确优先级与类型，支持逐条打标签建 issue。"
+canonical_path: "docs/plans/05-mvp-task-micro-breakdown.md"
+status: draft
+version: "1.0.0"
+owner: "StephenQiu30"
+inputs:
+  - "Superpowers 执行任务池"
+  - "已存在 issue #1-28"
+outputs:
+  - "可创建 issue 的微任务清单"
+triggers:
+  - "新一轮执行开始"
+  - "出现未覆盖功能风险"
+downstream:
+  - "docs/acceptance/01-mvp-acceptance-gates.md"
+  - "docs/design/01-frontend-runtime-design.md"
+---
+
+# MVP 前端任务微拆分（video-web）
+
+## Epic 分层
+
+- F1：项目初始化与基础设施（优先级 P0，类型 repo）
+- F2：工程/文档标准化（优先级 P0，类型 docs）
+- F3：产品页面（优先级 P0/P1，类型 core/ui/auth）
+- F4：测试与验收（优先级 P0，类型 test/review）
+
+## 微任务列表
+
+### F1（项目初始化）
+
+| Task ID | 标题 | 优先级 | 类型 | 说明 |
+| --- | --- | --- | --- | --- |
+| F1-S1 | 建立 App 入口 providers（QueryClient、Router、Auth）单测 | P0 | repo | `src/main.tsx`、`src/contexts/auth.tsx` |
+| F1-S2 | 补齐 `page` 路由文件占位并拆分为 4 个页面 | P0 | frontend | `src/pages/*` 与 `src/App.tsx` |
+| F1-S3 | 落地页样式系统与 token 入口文案 | P0 | ui | `src/App.css`、`src/index.css` |
+
+### F2（标准化）
+
+| Task ID | 标题 | 优先级 | 类型 | 说明 |
+| --- | --- | --- | --- | --- |
+| F2-S1 | 建立 docs 目录与更新 README/AGENTS | P0 | docs | 文档规范与目录入口 |
+| F2-S2 | 建立 `.env.example` 与运行说明 | P0 | devops | `VITE_API_BASE_URL`、轮询参数 |
+| F2-S3 | API 客户端方法按后端契约补齐字段映射 | P0 | api | `TaskRead` 与 `TaskEventRead` 对齐 |
+
+### F3（产品页面）
+
+| Task ID | 标题 | 优先级 | 类型 | 说明 |
+| --- | --- | --- | --- | --- |
+| F3-S1 | Auth 页面实现 token 落盘与回跳 | P0 | auth | `/auth?token=` 回跳接收 |
+| F3-S2 | Home 解析+创建任务链路：URL、format、错误态 | P0 | core | `parse` + `createTask` |
+| F3-S3 | Workbench 任务列表+状态过滤+失败重试入口 | P0 | core | 列表/分页/重试 |
+| F3-S4 | Task 详情：事件流、取消、重试、下载链接获取 | P0 | core | `cancel/retry/download-link` |
+| F3-S5 | 错误码统一映射与 toast/alert 提示 | P1 | ui | API 错误统一展示 |
+
+### F4（测试与验收）
+
+| Task ID | 标题 | 优先级 | 类型 | 说明 |
+| --- | --- | --- | --- | --- |
+| F4-S1 | 路由鉴权单测：未登录重定向到 /auth | P0 | test | `src/App.test.tsx` |
+| F4-S2 | 表单+任务详情组件单测 | P0 | test | `pages/*` 行为覆盖 |
+| F4-S3 | Playwright 登录链路 E2E（/auth + /workbench） | P0 | e2e | 验证真实浏览器路由 |
+| F4-S4 | Playwright 解析→创建→详情链路 E2E | P0 | e2e | 点击到可点击下载区 |
+| F4-S5 | Superpowers 审核与 Review 门禁 issue 执行 | P0 | code-review | 任务闭环 |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,29 @@
+---
+layer: plans
+doc_no: "PLANS"
+audience:
+  - PM
+  - Dev
+  - QA
+purpose: "统一记录 MVP 阶段任务拆分与优先级执行顺序。"
+canonical_path: "docs/plans/README.md"
+status: draft
+version: "0.1.0"
+owner: "StephenQiu30"
+inputs:
+  - "MVP PRD 需求、后端接口稳定度、Issue 反馈"
+outputs:
+  - "按 epic/task 分解的执行计划"
+triggers:
+  - "需求变化"
+  - "接口变更"
+  - "验收失败回归"
+downstream:
+  - "docs/design"
+  - "docs/acceptance"
+---
+
+# plans 说明
+
+- 仅存放长期计划文档（执行计划、里程碑、任务拆解）。
+- 需要可执行拆分：每个任务包含 `epic / 优先级 / 类型 / 产出 / 验收`。

--- a/docs/superpowers/plans/2026-05-23-video-web-mvp-react-ts-radix.md
+++ b/docs/superpowers/plans/2026-05-23-video-web-mvp-react-ts-radix.md
@@ -1,0 +1,106 @@
+# video-web MVP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox syntax for tracking.
+
+**Goal:** 建立可运行的视频下载器前端 MVP：落地页解析、登录态管理、工作台任务列表与任务详情，覆盖 TDD 与 E2E 主链路。
+
+**Architecture:** 前端作为独立仓库运行，统一通过 `/api/*` 与 `video-server` 对接；路由层负责访问控制，服务层统一在 `src/lib/api.ts`，页面层只做状态和交互编排。
+
+**Tech Stack:** React 19 + TypeScript + React Router + TanStack Query + Vitest + Playwright + CSS + Axios + Vite。
+
+---
+
+### Task 1: 建立文档与上下文索引
+
+- **Files:**
+  - Create: `docs/README.md`, `docs/plans/README.md`, `docs/design/README.md`, `docs/acceptance/README.md`, `docs/operations/README.md`, `docs/superpowers/plans/2026-05-23-video-web-mvp-react-ts-radix.md`
+
+- [ ] **Step 1: 写验收可追踪的文档骨架**
+  - [ ] 完成 `docs/` 下目录与 README。
+  - [ ] 写明每类文档用途与更新边界。
+  - [ ] 记录提交与命名规范（m1 前缀起始）。
+
+### Task 2: 实现页面骨架与鉴权守卫（最小可运行）
+
+- **Files:**
+  - Create: `src/pages/HomePage.tsx`, `src/pages/AuthPage.tsx`, `src/pages/WorkbenchPage.tsx`, `src/pages/TaskDetailPage.tsx`
+  - Modify: `src/App.tsx`, `src/App.css`, `src/index.css`
+
+- [ ] **Step 1: 写 failing 测试（路由与鉴权）**
+  - 先编写 `src/App.test.tsx`，覆盖未登录访问 `/workbench` 重定向。
+
+- [ ] **Step 2: 运行测试确认失败**
+  - `npm run test -- src/App.test.tsx`
+
+- [ ] **Step 3: 实现最小页面与鉴权重定向**
+  - 实现四个页面及公共布局，满足测试路径。
+
+- [ ] **Step 4: 运行测试确认通过**
+  - `npm run test -- src/App.test.tsx`
+
+### Task 3: 解析与任务创建主链路
+
+- **Files:**
+  - Modify: `src/pages/HomePage.tsx`, `src/lib/api.ts`, `src/App.tsx`
+  - Modify: `src/contexts/auth.tsx`
+
+- [ ] **Step 1: 写 failing 测试（解析→创建）**
+  - `src/pages/HomePage.test.tsx`：未登录不可提交、可解析可选 format。
+
+- [ ] **Step 2: 运行测试并确认失败**
+  - `npm run test -- src/pages/HomePage.test.tsx`
+
+- [ ] **Step 3: 实现最小业务逻辑**
+  - parse + createTask + 路由跳转
+
+- [ ] **Step 4: 运行测试通过**
+  - `npm run test -- src/pages/HomePage.test.tsx`
+
+### Task 4: 工作台与任务详情
+
+- **Files:**
+  - Modify: `src/pages/WorkbenchPage.tsx`, `src/pages/TaskDetailPage.tsx`
+
+- [ ] **Step 1: 写 failing 测试**
+  - `src/pages/WorkbenchPage.test.tsx` 验证空状态与按钮状态。
+  - `src/pages/TaskDetailPage.test.tsx` 验证取消/重试/下载入口状态。
+
+- [ ] **Step 2: 跑红灯测试**
+  - `npm run test -- src/pages/WorkbenchPage.test.tsx`
+  - `npm run test -- src/pages/TaskDetailPage.test.tsx`
+
+- [ ] **Step 3: 补最小实现**
+  - 列表、详情、事件、取消、重试、下载链路。
+
+- [ ] **Step 4: 跑绿灯测试**
+  - `npm run test -- src/pages/WorkbenchPage.test.tsx`
+  - `npm run test -- src/pages/TaskDetailPage.test.tsx`
+
+### Task 5: E2E + 验收
+
+- **Files:**
+  - Create: `tests/e2e/auth-to-workbench.spec.ts`, `playwright.config.ts`, `tests/e2e/playwright.config.ts`（如需）
+  - Modify: `package.json`
+
+- [ ] **Step 1: 写 failing E2E**
+  - 用 Playwright 验证无 token 的路由守卫与 token 注入后可达。
+
+- [ ] **Step 2: 运行测试确认预期失败**
+  - `npm run test:e2e -- tests/e2e/auth-to-workbench.spec.ts`
+
+- [ ] **Step 3: 实现最小可测路由行为**
+  - 完成 `AuthPage` token 写入、`Workbench` 可渲染、任务详情基本信息。
+
+- [ ] **Step 4: 运行并通过**
+  - `npm run test:e2e -- tests/e2e/auth-to-workbench.spec.ts`
+
+### Task 6: 文档与复盘
+
+- **Files:**
+  - Modify: `docs/plans/05-mvp-task-micro-breakdown.md`, `docs/acceptance/01-mvp-e2e.md`
+
+- [ ] **Step 1: 整理执行记录**
+  - 写入每个 Epic/Task 的状态。
+
+- [ ] **Step 2: 记录验证证据**
+  - 贴上 lint/test/e2e 命令输出和残留风险。


### PR DESCRIPTION
## 变更范围
- 建立 video-web 前端仓库初始治理结构（独立仓库思路、AGENTS、README、ENV 约定）
- 重建 docs 目录骨架与目录说明文件
- 完成文档约束的第一层齐套（docs 根目录+运行说明入口）

## 关联 Issue
Fixes #1, #2, #7, #8, #9, #10, #11, #12

## 验收与复盘
- 该 PR 为前端仓库治理底座，按 `docs/acceptance/01-mvp-acceptance-gates.md` 进入阶段一与阶段二的上下文说明。
- 与此 PR 对应的下游验证见 `docs/acceptance/02-issue-pr-映射.md`
