### PR TITLE
feat:m2-02 工作台AI与PDF报告体验

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -214,6 +214,13 @@
   margin-bottom: 12px;
 }
 
+.task-filters {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+
 .task-list {
   display: grid;
   gap: 10px;
@@ -229,6 +236,16 @@
   border-radius: 10px;
   padding: 10px 12px;
   background: #fcfbff;
+}
+
+.task-thumb {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  border-radius: 8px;
+  border: 1px solid #d9e6ff;
+  margin-bottom: 10px;
+  background: #eef5ff;
 }
 
 .task-title-row {
@@ -274,6 +291,26 @@
 
 .section-title {
   margin: 18px 0 10px;
+}
+
+.ai-summary-panel {
+  display: grid;
+  gap: 10px;
+  border: 1px solid #d7e6ff;
+  background: #f7fbff;
+  border-radius: 8px;
+  padding: 12px;
+  line-height: 1.7;
+}
+
+.mindmap {
+  display: grid;
+  gap: 6px;
+}
+
+.mindmap ul {
+  margin: 0;
+  padding-left: 18px;
 }
 
 .events {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -85,6 +85,10 @@ export type TaskRead = {
   ai_summary: string | null
   ai_status: string | null
   ai_error: string | null
+  ai_mindmap?: {
+    title: string
+    points: string[]
+  } | null
 }
 
 export type TaskEventRead = {
@@ -96,6 +100,11 @@ export type TaskEventRead = {
 }
 
 export type DownloadLink = {
+  url: string
+  expires_in_seconds: number
+}
+
+export type TaskReportLink = {
   url: string
   expires_in_seconds: number
 }
@@ -152,6 +161,14 @@ export const getTaskEvents = async (token: string | null, taskId: string): Promi
 export const getTaskDownloadLink = async (token: string | null, taskId: string): Promise<DownloadLink> => {
   requireAuth(token)
   const response = await api.get<DownloadLink>(`/tasks/${taskId}/download-link`, {
+    headers: authHeaders(token),
+  })
+  return response.data
+}
+
+export const getTaskReportLink = async (token: string | null, taskId: string): Promise<TaskReportLink> => {
+  requireAuth(token)
+  const response = await api.get<TaskReportLink>(`/tasks/${taskId}/report-link`, {
     headers: authHeaders(token),
   })
   return response.data

--- a/src/pages/TaskDetailPage.test.tsx
+++ b/src/pages/TaskDetailPage.test.tsx
@@ -7,6 +7,7 @@ import {
   getTask,
   getTaskDownloadLink,
   getTaskEvents,
+  getTaskReportLink,
   retryTask,
 } from '../lib/api'
 import { TaskDetailPage } from './TaskDetailPage'
@@ -20,6 +21,7 @@ vi.mock('../lib/api', async () => {
     getTask: vi.fn(),
     getTaskEvents: vi.fn(),
     getTaskDownloadLink: vi.fn(),
+    getTaskReportLink: vi.fn(),
   }
 })
 
@@ -142,6 +144,66 @@ describe('TaskDetailPage', () => {
     renderTaskDetailPage()
 
     expect(await screen.findByText('加载失败：任务加载失败')).toBeInTheDocument()
+  })
+
+  it('展示 AI 摘要、关键事件并可导出 PDF 报告', async () => {
+    vi.mocked(getTask).mockResolvedValue({
+      id: 't-detail',
+      source_url: 'https://www.bilibili.com/video/BV1xx411c7mD',
+      title: 'B站讲解视频',
+      cover_url: 'https://cdn.example.com/bili.jpg',
+      duration_seconds: 420,
+      state: 'SUCCEEDED',
+      progress: 100,
+      format_id: '1080',
+      format_label: '1080P MP4',
+      failure_code: null,
+      failure_reason: null,
+      output_filename: 'bili.mp4',
+      object_size: 8800000,
+      expires_at: '2026-01-01T00:00:00Z',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      attempt_no: 1,
+      is_latest_attempt: true,
+      retry_of_task_id: null,
+      ai_summary: '这是一段关于视频下载器工程化的摘要。',
+      ai_status: 'SUCCEEDED',
+      ai_error: null,
+      ai_mindmap: {
+        title: '工程化要点',
+        points: ['解析能力', '任务可靠性', '报告导出'],
+      },
+    })
+    vi.mocked(getTaskEvents).mockResolvedValue([
+      {
+        id: 1,
+        task_id: 't-detail',
+        state: 'AI_SUMMARY_DONE',
+        message: 'AI 摘要已生成',
+        created_at: '2026-01-01T00:01:00Z',
+      },
+    ])
+    vi.mocked(getTaskReportLink).mockResolvedValue({
+      url: 'https://example.com/report.pdf',
+      expires_in_seconds: 900,
+    })
+
+    renderTaskDetailPage()
+    const user = userEvent.setup()
+
+    expect(await screen.findByRole('heading', { name: 'AI 摘要' })).toBeInTheDocument()
+    expect(screen.getByText('这是一段关于视频下载器工程化的摘要。')).toBeInTheDocument()
+    expect(screen.getByText('工程化要点')).toBeInTheDocument()
+    expect(screen.getByText('报告导出')).toBeInTheDocument()
+    expect(screen.getByText('AI 摘要已生成')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: '导出 PDF 报告' }))
+
+    expect(await screen.findByRole('link', { name: '打开 PDF 报告' })).toHaveAttribute(
+      'href',
+      'https://example.com/report.pdf',
+    )
   })
 
   it('未登录时依赖组件层级重定向（通过 App 中间件）', () => {

--- a/src/pages/TaskDetailPage.tsx
+++ b/src/pages/TaskDetailPage.tsx
@@ -7,6 +7,7 @@ import {
   getTask,
   getTaskEvents,
   getTaskDownloadLink,
+  getTaskReportLink,
   retryTask,
   type TaskEventRead,
 } from '../lib/api'
@@ -32,6 +33,7 @@ export function TaskDetailPage() {
   const { token } = useAuth()
   const [errorText, setErrorText] = useState('')
   const [downloadUrl, setDownloadUrl] = useState('')
+  const [reportUrl, setReportUrl] = useState('')
 
   const { data: task, isLoading, isError, error } = useQuery({
     queryKey: ['task', taskId, token],
@@ -68,6 +70,15 @@ export function TaskDetailPage() {
     onError: (err) => setErrorText(parseErrorMessage(err)),
   })
 
+  const reportMut = useMutation({
+    mutationFn: async () => {
+      const result = await getTaskReportLink(token, taskId)
+      setReportUrl(result.url)
+      return result
+    },
+    onError: (err) => setErrorText(parseErrorMessage(err)),
+  })
+
   const latestEvents = useMemo(() => {
     if (!events.length) return []
     return events.slice(0, 30)
@@ -80,6 +91,7 @@ export function TaskDetailPage() {
   const canCancel = task.state === 'QUEUED' || task.state === 'STARTING' || task.state === 'DOWNLOADING'
   const canRetry = task.state === 'FAILED' || task.state === 'CANCELED'
   const canDownload = task.state === 'SUCCEEDED' && !downloadUrl
+  const canExportReport = task.state === 'SUCCEEDED' && !reportUrl
 
   return (
     <section className="page">
@@ -111,10 +123,23 @@ export function TaskDetailPage() {
             >
               {downloadMut.isPending ? '获取链接...' : canDownload ? '获取下载链接' : '不可下载'}
             </Button>
+            <Button
+              type="button"
+              onClick={() => reportMut.mutate()}
+              disabled={!canExportReport || reportMut.isPending}
+              variant="outline"
+            >
+              {reportMut.isPending ? '导出中...' : '导出 PDF 报告'}
+            </Button>
           </div>
           {downloadUrl && (
             <a className="download-link" href={downloadUrl} target="_blank" rel="noreferrer">
               打开下载文件
+            </a>
+          )}
+          {reportUrl && (
+            <a className="download-link" href={reportUrl} target="_blank" rel="noreferrer">
+              打开 PDF 报告
             </a>
           )}
           {errorText && (
@@ -123,6 +148,22 @@ export function TaskDetailPage() {
               <AlertDescription>{errorText}</AlertDescription>
             </Alert>
           )}
+
+          <h3 className="section-title">AI 摘要</h3>
+          <div className="ai-summary-panel">
+            {task.ai_summary ? <p>{task.ai_summary}</p> : <p className="task-meta">暂无摘要，任务完成后会自动生成。</p>}
+            {task.ai_error && <p className="error-text">{task.ai_error}</p>}
+            {task.ai_mindmap && (
+              <div className="mindmap">
+                <strong>{task.ai_mindmap.title}</strong>
+                <ul>
+                  {task.ai_mindmap.points.map((point) => (
+                    <li key={point}>{point}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
 
           <h3 className="section-title">事件流</h3>
           <ul className="events">

--- a/src/pages/WorkbenchPage.test.tsx
+++ b/src/pages/WorkbenchPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach } from 'vitest'
 
 import { listTasks } from '../lib/api'
@@ -131,6 +132,75 @@ describe('WorkbenchPage', () => {
     expect(await screen.findByText('失败：1')).toBeInTheDocument()
     expect(await screen.findByText('成功：1')).toBeInTheDocument()
     expect(await screen.findByText('失败视频')).toBeInTheDocument()
+  })
+
+  it('可按任务状态筛选并展示封面与能力状态', async () => {
+    vi.mocked(listTasks).mockResolvedValueOnce([
+      {
+        id: 't-running',
+        source_url: 'https://v.douyin.com/running',
+        title: '正在下载的视频',
+        cover_url: 'https://cdn.example.com/running.jpg',
+        duration_seconds: 95,
+        state: 'DOWNLOADING',
+        progress: 42,
+        format_id: '1080',
+        format_label: '1080P MP4',
+        failure_code: null,
+        failure_reason: null,
+        output_filename: null,
+        object_size: null,
+        expires_at: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        attempt_no: 1,
+        is_latest_attempt: true,
+        retry_of_task_id: null,
+        ai_summary: null,
+        ai_status: 'PENDING',
+        ai_error: null,
+      },
+      {
+        id: 't-done',
+        source_url: 'https://www.bilibili.com/video/BV1xx411c7mD',
+        title: '已完成的视频',
+        cover_url: 'https://cdn.example.com/done.jpg',
+        duration_seconds: 360,
+        state: 'SUCCEEDED',
+        progress: 100,
+        format_id: '720',
+        format_label: '720P MP4',
+        failure_code: null,
+        failure_reason: null,
+        output_filename: 'done.mp4',
+        object_size: 1200000,
+        expires_at: '2026-01-02T00:00:00Z',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        attempt_no: 1,
+        is_latest_attempt: true,
+        retry_of_task_id: null,
+        ai_summary: '已生成摘要',
+        ai_status: 'SUCCEEDED',
+        ai_error: null,
+      },
+    ])
+
+    const user = userEvent.setup()
+    renderWithProviders(<WorkbenchPage />)
+
+    expect(await screen.findByAltText('正在下载的视频')).toHaveAttribute(
+      'src',
+      'https://cdn.example.com/running.jpg',
+    )
+    expect(screen.getByText('时长：01:35')).toBeInTheDocument()
+    expect(screen.getByText('AI：等待处理')).toBeInTheDocument()
+    expect(screen.getByText('报告：可导出')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: '已完成' }))
+
+    expect(screen.queryByText('正在下载的视频')).not.toBeInTheDocument()
+    expect(screen.getByText('已完成的视频')).toBeInTheDocument()
   })
 
   it('错误态能展示任务列表请求异常', async () => {

--- a/src/pages/WorkbenchPage.tsx
+++ b/src/pages/WorkbenchPage.tsx
@@ -1,10 +1,11 @@
 import { Link } from 'react-router-dom'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 
 import { listTasks, type TaskRead } from '../lib/api'
 import { useAuth } from '../contexts/auth'
 import { Badge } from '../components/ui/badge'
+import { Button } from '../components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
 import { Progress } from '../components/ui/progress'
 
@@ -17,6 +18,15 @@ const STATE_TAG: Record<string, string> = {
   CANCELED: 'canceled',
 }
 
+const FILTERS = [
+  { key: 'ALL', label: '全部' },
+  { key: 'RUNNING', label: '进行中' },
+  { key: 'SUCCEEDED', label: '已完成' },
+  { key: 'FAILED', label: '失败' },
+] as const
+
+type TaskFilter = (typeof FILTERS)[number]['key']
+
 function stateBadge(state: string) {
   return <Badge className={`state-${STATE_TAG[state] ?? 'pending'}`}>{state}</Badge>
 }
@@ -27,8 +37,30 @@ function formatDate(value: string) {
   return date.toLocaleString()
 }
 
+function formatDuration(seconds?: number | null) {
+  if (!seconds) return '未知'
+  const minutes = Math.floor(seconds / 60)
+  const rest = seconds % 60
+  return `${String(minutes).padStart(2, '0')}:${String(rest).padStart(2, '0')}`
+}
+
+function aiStatusLabel(status?: string | null) {
+  if (status === 'SUCCEEDED') return '已生成'
+  if (status === 'FAILED') return '失败'
+  if (status === 'PENDING') return '等待处理'
+  if (status === 'PROCESSING') return '生成中'
+  return '未开始'
+}
+
+function matchesFilter(task: TaskRead, filter: TaskFilter) {
+  if (filter === 'ALL') return true
+  if (filter === 'RUNNING') return ['PENDING', 'QUEUED', 'STARTING', 'DOWNLOADING', 'MERGING', 'PROCESSING'].includes(task.state)
+  return task.state === filter
+}
+
 export function WorkbenchPage() {
   const { token } = useAuth()
+  const [filter, setFilter] = useState<TaskFilter>('ALL')
   const { data: tasks = [], isLoading, isError, error } = useQuery({
     queryKey: ['tasks', token],
     queryFn: () => listTasks(token),
@@ -45,6 +77,8 @@ export function WorkbenchPage() {
     }
   }, [tasks])
 
+  const visibleTasks = useMemo(() => tasks.filter((task) => matchesFilter(task, filter)), [filter, tasks])
+
   return (
     <section className="page">
       <Card>
@@ -60,6 +94,19 @@ export function WorkbenchPage() {
             <span>失败：{summary.failed}</span>
           </div>
 
+          <div className="task-filters" aria-label="任务筛选">
+            {FILTERS.map((item) => (
+              <Button
+                key={item.key}
+                type="button"
+                variant={filter === item.key ? 'default' : 'outline'}
+                onClick={() => setFilter(item.key)}
+              >
+                {item.label}
+              </Button>
+            ))}
+          </div>
+
           {isLoading && <p>任务加载中...</p>}
 
           {!isLoading && isError && <p className="error-text">{(error as Error).message}</p>}
@@ -69,14 +116,18 @@ export function WorkbenchPage() {
           )}
 
           <div className="task-list">
-            {tasks.map((task: TaskRead) => (
+            {visibleTasks.map((task: TaskRead) => (
               <Link to={`/tasks/${task.id}`} key={task.id} className="task-card-link">
                 <article className="task-card">
+                  {task.cover_url && <img className="task-thumb" src={task.cover_url} alt={task.title || task.source_url} />}
                   <div className="task-title-row">
                     <h4>{task.title || task.source_url}</h4>
                     {stateBadge(task.state)}
                   </div>
                   <p className="task-meta">格式：{task.format_label || task.format_id || '默认'}</p>
+                  <p className="task-meta">时长：{formatDuration(task.duration_seconds)}</p>
+                  <p className="task-meta">AI：{aiStatusLabel(task.ai_status)}</p>
+                  <p className="task-meta">报告：{task.state === 'SUCCEEDED' ? '可导出' : '待完成'}</p>
                   <Progress value={task.progress} />
                   <p className="task-meta">更新时间：{formatDate(task.updated_at)}</p>
                 </article>


### PR DESCRIPTION
## 变更说明
- 工作台增加状态筛选、封面、时长、AI 状态与 PDF 报告可导出提示。
- 任务详情页增加 AI 摘要、结构化要点展示、AI 事件可见性。
- 增加 PDF 报告导出入口与 `getTaskReportLink` API 客户端封装。

## TDD / 验证
- Red: `npx vitest run src/pages/WorkbenchPage.test.tsx src/pages/TaskDetailPage.test.tsx` 确认工作台与 AI/PDF 用例失败。
- Green: `npx vitest run src/pages/WorkbenchPage.test.tsx src/pages/TaskDetailPage.test.tsx`
- `npm run lint`
- `npm run build`
- `npm test`

Closes #45
Closes #46
Closes #47
