### PR TITLE
feat:m2-03 蓝白视觉与AI报告E2E

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,7 +3,7 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  background: linear-gradient(180deg, #f8fbff 0%, #f7f4ff 42%, #ffffff 100%);
+  background: linear-gradient(180deg, #f7fbff 0%, #ffffff 48%, #f8fbff 100%);
 }
 
 .app-header {
@@ -26,7 +26,7 @@
 }
 
 .brand-sub {
-  color: #7b6f92;
+  color: #4d6078;
   font-size: 12px;
 }
 
@@ -39,13 +39,13 @@
 .header-nav a {
   padding: 8px 12px;
   border-radius: 8px;
-  color: #1f2441;
+  color: #0f2238;
   text-decoration: none;
 }
 
 .header-nav a.active {
-  background: #efe9ff;
-  color: #5b3cff;
+  background: #e8f2ff;
+  color: #0b63ce;
 }
 
 .app-main {
@@ -57,7 +57,7 @@
 .app-footer {
   padding: 16px 24px;
   border-top: 1px solid var(--border);
-  color: #7a7590;
+  color: #60758f;
   font-size: 12px;
   text-align: center;
 }
@@ -86,7 +86,7 @@
 }
 
 .hero-copy p {
-  color: #4b587c;
+  color: #4d6078;
   font-size: 17px;
   line-height: 1.7;
 }
@@ -125,14 +125,14 @@
 }
 
 .form-label {
-  color: #1f2441;
+  color: #0f2238;
   font-size: 14px;
 }
 
 .helper-text {
   font-size: 13px;
   margin-top: 8px;
-  color: #6a6177;
+  color: #4d6078;
 }
 
 .helper-text a {
@@ -141,7 +141,7 @@
 
 .state-text {
   min-height: 24px;
-  color: #4f4b61;
+  color: #334b68;
 }
 
 .platform-tag {
@@ -162,8 +162,8 @@
 .parse-result {
   border: 1px solid var(--border);
   padding: 10px 12px;
-  border-radius: 12px;
-  background: #fbfaff;
+  border-radius: 8px;
+  background: #f8fbff;
 }
 
 .result-cover {
@@ -198,7 +198,7 @@
 }
 
 .format-item small {
-  color: #766d86;
+  color: #60758f;
   font-size: 12px;
 }
 
@@ -210,7 +210,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  color: #4b4861;
+  color: #334b68;
   margin-bottom: 12px;
 }
 
@@ -232,10 +232,10 @@
 }
 
 .task-card {
-  border: 1px solid #eceaf0;
-  border-radius: 10px;
+  border: 1px solid #dbe7f6;
+  border-radius: 8px;
   padding: 10px 12px;
-  background: #fcfbff;
+  background: #ffffff;
 }
 
 .task-thumb {
@@ -257,16 +257,16 @@
 
 .task-title-row h4 {
   margin: 0;
-  color: #1f2441;
+  color: #0f2238;
 }
 
 .task-meta {
-  color: #746f87;
+  color: #60758f;
   font-size: 13px;
 }
 
 .empty-state {
-  color: #746f87;
+  color: #60758f;
 }
 
 .task-meta-row {
@@ -286,7 +286,7 @@
 .download-link {
   display: inline-block;
   margin-top: 8px;
-  color: #4f46e5;
+  color: #0b63ce;
 }
 
 .section-title {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,12 +12,12 @@ function AppHeader() {
   return (
     <header className="app-header">
       <div className="brand">
-        <span>VideoWeb</span>
-        <span className="brand-sub">AI 工具化下载</span>
+        <span>万能视频下载器</span>
+        <span className="brand-sub">解析 · 队列 · AI 报告</span>
       </div>
       <nav className="header-nav">
         <NavLink to="/" end>
-          落地页
+          解析
         </NavLink>
         <NavLink to="/workbench">工作台</NavLink>
         <NavLink to="/auth">登录 / 注册</NavLink>

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,7 @@
 :root {
-  --text: #1f2441;
-  --text-soft: #5b5670;
-  --border: #e8e1f5;
+  --text: #0f2238;
+  --text-soft: #4d6078;
+  --border: #dbe7f6;
   --bg: #f8fbff;
   --card-bg: #ffffff;
 }
@@ -32,7 +32,7 @@ body {
 }
 
 a {
-  color: #4f46e5;
+  color: #0b63ce;
 }
 
 h1,
@@ -64,7 +64,7 @@ p {
 }
 
 .btn-primary {
-  background: #4f46e5;
+  background: #0b63ce;
   color: #fff;
 }
 
@@ -73,8 +73,8 @@ p {
 }
 
 .btn-outline {
-  border-color: #c4c4cf;
-  background: #f7f7fb;
+  border-color: #b9cbe4;
+  background: #f7fbff;
 }
 
 .btn:disabled {
@@ -84,7 +84,7 @@ p {
 
 .input {
   width: 100%;
-  border: 1px solid #d7d8e0;
+  border: 1px solid #c9d7ea;
   background: #fff;
   border-radius: 10px;
   padding: 10px 12px;
@@ -92,14 +92,14 @@ p {
 }
 
 .input:focus-visible {
-  outline: 2px solid #b3b9ff;
+  outline: 2px solid #8ec5ff;
 }
 
 .card {
   border: 1px solid var(--border);
-  border-radius: 14px;
+  border-radius: 8px;
   background: var(--card-bg);
-  box-shadow: 0 8px 20px rgba(95, 64, 255, 0.08);
+  box-shadow: 0 10px 28px rgba(35, 80, 127, 0.08);
   padding: 18px;
 }
 
@@ -118,10 +118,10 @@ p {
 }
 
 .badge {
-  border-radius: 999px;
+  border-radius: 8px;
   padding: 4px 8px;
-  background: #eef2ff;
-  color: #3730a3;
+  background: #e8f2ff;
+  color: #084c9a;
   font-size: 12px;
   display: inline-flex;
 }
@@ -129,7 +129,7 @@ p {
 .progress-track {
   width: 100%;
   height: 8px;
-  background: #edf2ff;
+  background: #e8f2ff;
   border-radius: 999px;
   overflow: hidden;
 }
@@ -137,7 +137,7 @@ p {
 .progress-bar {
   height: 100%;
   border-radius: 999px;
-  background: linear-gradient(90deg, #7c3aed, #2563eb);
+  background: #0b63ce;
 }
 
 .alert {
@@ -149,9 +149,9 @@ p {
 
 .alert-title {
   margin-bottom: 6px;
-  color: #86198f;
+  color: #9f1239;
 }
 
 .alert-description {
-  color: #581c87;
+  color: #7f1d1d;
 }

--- a/tests/e2e/parse-create-detail.spec.ts
+++ b/tests/e2e/parse-create-detail.spec.ts
@@ -114,6 +114,18 @@ test('解析分享链接并创建任务后可进入详情页获取下载链接',
       return
     }
 
+    if (route.request().url().endsWith('/report-link')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          url: 'https://cdn.example.com/report.pdf',
+          expires_in_seconds: 900,
+        }),
+      })
+      return
+    }
+
     await route.fulfill({
       status: 200,
       contentType: 'application/json',

--- a/tests/e2e/parse-create-detail.spec.ts
+++ b/tests/e2e/parse-create-detail.spec.ts
@@ -17,9 +17,13 @@ test('解析分享链接并创建任务后可进入详情页获取下载链接',
     attempt_no: 1,
     is_latest_attempt: true,
     retry_of_task_id: null,
-    ai_summary: null,
-    ai_status: null,
+    ai_summary: 'AI 已提炼视频重点，适合生成分享报告。',
+    ai_status: 'SUCCEEDED',
     ai_error: null,
+    ai_mindmap: {
+      title: '报告要点',
+      points: ['视频亮点', '下载规格', '分享建议'],
+    },
   }
 
   await page.addInitScript(() => {
@@ -129,6 +133,9 @@ test('解析分享链接并创建任务后可进入详情页获取下载链接',
 
   await expect(page).toHaveURL(/\/tasks\/t-e2e-01/)
   await expect(page.getByText('抖音样例视频')).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'AI 摘要' })).toBeVisible()
+  await expect(page.getByText('AI 已提炼视频重点，适合生成分享报告。')).toBeVisible()
+  await expect(page.getByText('报告要点')).toBeVisible()
   await expect(page.getByText('事件流')).toBeVisible()
   await expect(page.getByText('下载完成')).toBeVisible()
 
@@ -138,5 +145,11 @@ test('解析分享链接并创建任务后可进入详情页获取下载链接',
   await expect(page.getByRole('link', { name: '打开下载文件' })).toHaveAttribute(
     'href',
     'https://cdn.example.com/video.mp4',
+  )
+
+  await page.getByRole('button', { name: '导出 PDF 报告' }).click()
+  await expect(page.getByRole('link', { name: '打开 PDF 报告' })).toHaveAttribute(
+    'href',
+    'https://cdn.example.com/report.pdf',
   )
 })


### PR DESCRIPTION
## 变更说明
- 将整体视觉收敛为简约蓝白主题，减少紫色系和过度装饰，品牌与导航文案贴近解析工具定位。
- Playwright E2E 增加 AI 摘要与 PDF 报告导出链路验证。
- 补齐 report-link mock，确保解析、创建、详情、下载、报告导出闭环可回归。

## TDD / 验证
- Red: `npx playwright test tests/e2e/parse-create-detail.spec.ts` 确认 PDF 报告链接缺失失败。
- Green: `npx playwright test tests/e2e/parse-create-detail.spec.ts`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:e2e`

Closes #48
Closes #49
