### PR TITLE
fix:m2-04 对齐PDF契约与mindmap兼容

### DIFF
--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { api, getTaskReportLink } from './api'
+
+describe('api report contract', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('通过真实后端 PDF 接口拉取 blob 并生成临时报告 URL', async () => {
+    const pdf = new Blob(['%PDF-1.4'], { type: 'application/pdf' })
+    const getSpy = vi.spyOn(api, 'get').mockResolvedValue({ data: pdf })
+    URL.createObjectURL = vi.fn()
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:http://localhost/report')
+
+    const result = await getTaskReportLink('unit-token', 'task-1')
+
+    expect(getSpy).toHaveBeenCalledWith('/tasks/task-1/pdf', {
+      headers: { Authorization: 'Bearer unit-token' },
+      responseType: 'blob',
+    })
+    expect(createObjectURL).toHaveBeenCalledWith(pdf)
+    expect(result).toEqual({
+      url: 'blob:http://localhost/report',
+      expires_in_seconds: 0,
+    })
+  })
+})

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -85,10 +85,13 @@ export type TaskRead = {
   ai_summary: string | null
   ai_status: string | null
   ai_error: string | null
-  ai_mindmap?: {
+  ai_mindmap?:
+    | {
     title: string
     points: string[]
-  } | null
+  }
+    | string
+    | null
 }
 
 export type TaskEventRead = {
@@ -168,10 +171,14 @@ export const getTaskDownloadLink = async (token: string | null, taskId: string):
 
 export const getTaskReportLink = async (token: string | null, taskId: string): Promise<TaskReportLink> => {
   requireAuth(token)
-  const response = await api.get<TaskReportLink>(`/tasks/${taskId}/report-link`, {
+  const response = await api.get<Blob>(`/tasks/${taskId}/pdf`, {
     headers: authHeaders(token),
+    responseType: 'blob',
   })
-  return response.data
+  return {
+    url: URL.createObjectURL(response.data),
+    expires_in_seconds: 0,
+  }
 }
 
 export const cancelTask = async (token: string | null, taskId: string): Promise<TaskRead> => {

--- a/src/pages/TaskDetailPage.test.tsx
+++ b/src/pages/TaskDetailPage.test.tsx
@@ -170,10 +170,10 @@ describe('TaskDetailPage', () => {
       ai_summary: '这是一段关于视频下载器工程化的摘要。',
       ai_status: 'SUCCEEDED',
       ai_error: null,
-      ai_mindmap: {
+      ai_mindmap: JSON.stringify({
         title: '工程化要点',
         points: ['解析能力', '任务可靠性', '报告导出'],
-      },
+      }),
     })
     vi.mocked(getTaskEvents).mockResolvedValue([
       {
@@ -185,7 +185,7 @@ describe('TaskDetailPage', () => {
       },
     ])
     vi.mocked(getTaskReportLink).mockResolvedValue({
-      url: 'https://example.com/report.pdf',
+      url: 'blob:http://localhost/report',
       expires_in_seconds: 900,
     })
 
@@ -202,7 +202,7 @@ describe('TaskDetailPage', () => {
 
     expect(await screen.findByRole('link', { name: '打开 PDF 报告' })).toHaveAttribute(
       'href',
-      'https://example.com/report.pdf',
+      'blob:http://localhost/report',
     )
   })
 

--- a/src/pages/TaskDetailPage.tsx
+++ b/src/pages/TaskDetailPage.tsx
@@ -27,6 +27,36 @@ function stateName(state: string) {
   return state.toUpperCase()
 }
 
+type MindmapView = {
+  title: string
+  points: string[]
+}
+
+function parseMindmap(value: unknown): MindmapView | null {
+  if (!value) return null
+  if (typeof value === 'object' && value !== null) {
+    const candidate = value as { title?: unknown; points?: unknown }
+    return {
+      title: typeof candidate.title === 'string' ? candidate.title : '关键要点',
+      points: Array.isArray(candidate.points) ? candidate.points.filter((item): item is string => typeof item === 'string') : [],
+    }
+  }
+  if (typeof value !== 'string') return null
+
+  try {
+    const parsed = JSON.parse(value) as unknown
+    return parseMindmap(parsed)
+  } catch {
+    return {
+      title: '关键要点',
+      points: value
+        .split(/\n+/)
+        .map((item) => item.replace(/^[-*]\s*/, '').trim())
+        .filter(Boolean),
+    }
+  }
+}
+
 export function TaskDetailPage() {
   const navigate = useNavigate()
   const { taskId = '' } = useParams()
@@ -92,6 +122,7 @@ export function TaskDetailPage() {
   const canRetry = task.state === 'FAILED' || task.state === 'CANCELED'
   const canDownload = task.state === 'SUCCEEDED' && !downloadUrl
   const canExportReport = task.state === 'SUCCEEDED' && !reportUrl
+  const mindmap = parseMindmap(task.ai_mindmap)
 
   return (
     <section className="page">
@@ -153,11 +184,11 @@ export function TaskDetailPage() {
           <div className="ai-summary-panel">
             {task.ai_summary ? <p>{task.ai_summary}</p> : <p className="task-meta">暂无摘要，任务完成后会自动生成。</p>}
             {task.ai_error && <p className="error-text">{task.ai_error}</p>}
-            {task.ai_mindmap && (
+            {mindmap && (
               <div className="mindmap">
-                <strong>{task.ai_mindmap.title}</strong>
+                <strong>{mindmap.title}</strong>
                 <ul>
-                  {task.ai_mindmap.points.map((point) => (
+                  {mindmap.points.map((point) => (
                     <li key={point}>{point}</li>
                   ))}
                 </ul>

--- a/tests/e2e/parse-create-detail.spec.ts
+++ b/tests/e2e/parse-create-detail.spec.ts
@@ -20,10 +20,10 @@ test('解析分享链接并创建任务后可进入详情页获取下载链接',
     ai_summary: 'AI 已提炼视频重点，适合生成分享报告。',
     ai_status: 'SUCCEEDED',
     ai_error: null,
-    ai_mindmap: {
+    ai_mindmap: JSON.stringify({
       title: '报告要点',
       points: ['视频亮点', '下载规格', '分享建议'],
-    },
+    }),
   }
 
   await page.addInitScript(() => {
@@ -114,14 +114,11 @@ test('解析分享链接并创建任务后可进入详情页获取下载链接',
       return
     }
 
-    if (route.request().url().endsWith('/report-link')) {
+    if (route.request().url().endsWith('/pdf')) {
       await route.fulfill({
         status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          url: 'https://cdn.example.com/report.pdf',
-          expires_in_seconds: 900,
-        }),
+        contentType: 'application/pdf',
+        body: '%PDF-1.4',
       })
       return
     }
@@ -160,8 +157,5 @@ test('解析分享链接并创建任务后可进入详情页获取下载链接',
   )
 
   await page.getByRole('button', { name: '导出 PDF 报告' }).click()
-  await expect(page.getByRole('link', { name: '打开 PDF 报告' })).toHaveAttribute(
-    'href',
-    'https://cdn.example.com/report.pdf',
-  )
+  await expect(page.getByRole('link', { name: '打开 PDF 报告' })).toHaveAttribute('href', /^blob:/)
 })


### PR DESCRIPTION
## 变更说明
- 对齐真实后端 PDF 契约：前端改为请求 `/api/tasks/{id}/pdf`，携带 Authorization 并生成 blob URL。
- 兼容后端 `ai_mindmap` JSON 字符串，避免任务详情页运行时崩溃。
- E2E mock 改为真实 `/pdf` 返回 `application/pdf`，验证报告链接为 blob URL。

## TDD / 验证
- Red: `npx vitest run src/lib/api.test.ts src/pages/TaskDetailPage.test.tsx` 确认 `/report-link` 契约与字符串 mindmap 失败。
- Green: `npx vitest run src/lib/api.test.ts src/pages/TaskDetailPage.test.tsx`
- `npx playwright test tests/e2e/parse-create-detail.spec.ts`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:e2e`

Closes #53
