### PR TITLE
docs:m3-00 SaaS布局与OpenAPI生成任务规划

### DIFF
--- a/docs/design/03-saas-layout-api-generated-redesign.md
+++ b/docs/design/03-saas-layout-api-generated-redesign.md
@@ -1,0 +1,323 @@
+---
+layer: design
+doc_no: "DESIGN-003"
+audience:
+  - PM
+  - Dev
+  - QA
+feature_area: saas-layout-openapi
+purpose: "定义 video-web 解析下载优先的 SaaS 顶部布局、响应式页面、异常机制与 OpenAPI 生成 API 方案。"
+canonical_path: "docs/design/03-saas-layout-api-generated-redesign.md"
+status: draft
+version: "0.1.0"
+owner: "StephenQiu30"
+inputs:
+  - "AGENTS.md"
+  - "video-server Swagger/OpenAPI 契约"
+  - "docs/design/02-conversion-first-parser-ai-pdf-redesign.md"
+outputs:
+  - "SaaS 顶部布局与页面功能设计"
+  - "异常状态与错误处理边界"
+  - "OpenAPI 生成 API client 设计"
+triggers:
+  - "前端主布局重构"
+  - "任务页、报告入口或账号页改造"
+  - "后端接口契约变更"
+downstream:
+  - "docs/plans/07-saas-layout-api-generated-issues.md"
+  - "docs/acceptance/02-issue-pr-映射.md"
+---
+
+# SaaS 顶部布局与 OpenAPI API 生成设计
+
+## 1. 背景
+
+`video-web` 已完成解析、任务、AI 摘要和 PDF 报告的 MVP 闭环，但当前页面仍偏 MVP 验证台：顶部导航薄、页面缺少统一标题区、任务列表密度不足、异常状态分散，API 类型仍主要由 `src/lib/api.ts` 手写维护。下一阶段目标是把前端提升为克制、可信、响应式的成熟 SaaS 平台，同时不脱离“万能视频下载器”的核心使用路径。
+
+本设计参考 Ant Design Pro 的 TopNav、PageContainer、ProTable 信息密度和账号区布局范式，但保留当前 React + TypeScript + RadixUI 技术栈，不引入 Umi、Ant Design 或 Pro Components。
+
+## 2. 目标
+
+- 以“解析下载优先”为主线，保持最短路径：粘贴链接 -> 解析 -> 选格式 -> 创建任务 -> 看进度 -> 下载文件 / 导出报告。
+- 使用蓝白色主题，形成统一的顶部 SaaS 布局、页面标题区、内容容器和响应式规则。
+- 顶部导航采用 4 个入口：解析、任务、报告、账号。
+- 报告入口不做独立空报告中心，而是跳转到已完成任务筛选。
+- 新增账号页，展示当前账号、任务额度、并发额度、文件大小、存储额度和文件保留时间。
+- 建立统一异常状态机制：404、401、403、网络错误、空状态、模块错误。
+- 基于后端 Swagger/OpenAPI 文档生成前端 API 文件，减少手写 DTO 漂移。
+- Vite 本地调试使用默认地址 `http://localhost:5173/`。
+
+## 3. 非目标
+
+- 不引入 Ant Design、Umi、Pro Components 或新路由框架。
+- 不做复杂营销首页、仪表盘大屏、计费订阅、团队协作或通知中心。
+- 不做独立报告中心；报告入口仅作为任务筛选快捷入口。
+- 不在本阶段重写所有业务逻辑为 hooks 框架；只围绕本次页面和 API 契约做必要拆分。
+- 不手写复杂 Table 抽象、主题 DSL 或过度通用组件。
+
+## 4. 路由与导航
+
+| 路由 | 名称 | 鉴权 | 说明 |
+| --- | --- | --- | --- |
+| `/` | 解析 | 否 | 默认入口，首屏解析器和解析结果 |
+| `/tasks` | 任务 | 是 | 任务列表、状态筛选、任务管理 |
+| `/tasks?state=SUCCEEDED` | 报告 | 是 | 顶部“报告”入口跳转目标，复用任务页已完成筛选 |
+| `/tasks/:taskId` | 任务详情 | 是 | 状态、事件、操作、下载、PDF 导出 |
+| `/account` | 账号 | 是 | 用户资料与额度 |
+| `/auth` | 登录 | 否 | 登录入口与 token 回跳 |
+| `/workbench` | 兼容重定向 | 是 | 重定向到 `/tasks`，保留旧链接可用性 |
+| `*` | 404 | 否 | 未知路由展示 NotFoundPage |
+
+顶部布局：
+
+- 左侧：产品名“万能视频下载器”和简短副标题。
+- 中间：解析、任务、报告、账号。
+- 右侧：未登录显示“登录”，已登录显示用户名称或邮箱缩写、退出入口。
+- 移动端：导航可横向滚动或折叠为紧凑入口，优先保证“解析”和“任务”可见。
+
+## 5. 页面功能设计
+
+### 5.1 解析页 `/`
+
+核心功能是链接解析和创建任务。
+
+- PageHeader：标题“万能视频解析下载器”，描述当前支持公开分享链接解析。
+- ParserPanel：视频链接输入框、解析按钮、登录提示。
+- ParseResultPanel：封面、标题、平台、合规提示、格式列表、创建任务按钮。
+- CapabilityStrip：只展示真实能力，多平台解析、格式选择、任务队列、PDF 报告。
+- 未登录点击解析时保存 `sessionStorage.video_web_pending_url` 并跳转 `/auth`。
+- 登录回跳后恢复 pending URL，继续停留在解析页。
+
+### 5.2 任务页 `/tasks`
+
+核心功能是任务管理。
+
+- PageHeader：标题“下载任务”，右侧提供“新建解析”按钮。
+- TaskFilters：全部、进行中、已完成、失败。
+- 桌面端：列表/表格型任务行，字段为标题、状态、进度、格式、更新时间、操作。
+- 移动端：任务卡片，展示标题、状态、进度、格式、更新时间和详情入口。
+- 列表操作保持克制，只保留“详情”；下载和 PDF 导出进入详情页执行。
+- 空态：没有任务时引导返回解析页。
+
+### 5.3 报告入口
+
+顶部“报告”不是独立页面，而是跳转 `/tasks?state=SUCCEEDED`。
+
+- 任务页读取 query 参数并选中“已完成”筛选。
+- 已完成任务在列表中提示“报告可导出”。
+- 如果没有已完成任务，显示“暂无可导出的报告”，并引导返回解析页。
+
+### 5.4 任务详情 `/tasks/:taskId`
+
+核心功能是任务状态与操作。
+
+- 状态摘要：标题、状态、进度、格式、更新时间。
+- 操作区：返回任务、取消、重试、获取下载链接、导出 PDF 报告。
+- AI 摘要区：存在 `ai_summary` 或 `ai_mindmap` 时展示；不存在时显示轻量空态。
+- 事件流：保留日志列表，不做复杂时间线。
+- PDF 导出：只在任务完成后启用，请求后端 `/api/tasks/{task_id}/pdf` 并使用 blob URL 下载或打开。
+
+### 5.5 账号页 `/account`
+
+只展示基础资料和额度，不做完整设置中心。
+
+- AccountSummary：邮箱、显示名、头像、账号状态。
+- QuotaList：每日任务额度、并发额度、最大文件大小、存储额度、文件保留时间。
+- 未登录访问时跳转 `/auth`。
+- 已登录可退出，退出后清理 token 并回到解析页。
+
+## 6. 布局与视觉规范
+
+设计目标是“干净、有层级、可扫视”。
+
+| Token | 值 | 用途 |
+| --- | --- | --- |
+| Primary | `#1677ff` | 主按钮、链接、关键状态 |
+| Primary hover | `#4096ff` | 悬停与轻强调 |
+| Text | `#101828` | 主文本 |
+| Muted | `#475467` | 辅助文本 |
+| Border | `#d0d7e2` | 边框 |
+| Page bg | `#f5f8fc` | 页面背景 |
+| Surface | `#ffffff` | 内容区 |
+| Success | `#16a34a` | 成功状态 |
+| Warning | `#f59e0b` | 等待/警告 |
+| Error | `#dc2626` | 错误状态 |
+
+布局约束：
+
+- 顶部导航高度控制在 56-60px。
+- 桌面内容区 `max-width: 1180px`，移动端左右 16px。
+- 页面使用 PageContainer：标题区、操作区、内容区。
+- 页面本身不套一个大卡片；卡片只用于独立模块或任务卡片。
+- 卡片圆角 8px，按钮和输入框满足 44px 触控目标。
+- 不使用大面积紫色渐变、装饰性 blob、复杂插画或营销大屏。
+- 动效控制在 150-300ms，并尊重 `prefers-reduced-motion`。
+
+## 7. 组件化边界
+
+只做服务当前需求的组件，不做过度抽象。
+
+```text
+src/components/layout/
+  AppLayout.tsx
+  PageContainer.tsx
+  PageHeader.tsx
+
+src/components/states/
+  EmptyState.tsx
+  ErrorState.tsx
+  LoadingState.tsx
+  NotFoundPage.tsx
+  ForbiddenState.tsx
+
+src/features/parser/
+  ParserPanel.tsx
+  ParseResultPanel.tsx
+
+src/features/tasks/
+  TaskFilters.tsx
+  TaskList.tsx
+  TaskMobileCard.tsx
+  TaskStatusBadge.tsx
+
+src/features/account/
+  AccountSummary.tsx
+  QuotaList.tsx
+
+src/services/
+  generated/
+  request.ts
+  api.ts
+```
+
+拆分原则：
+
+- 页面负责路由和数据编排。
+- feature 组件负责单一业务展示和交互。
+- `components/layout` 只处理布局，不理解任务业务。
+- `components/states` 只处理状态反馈，不发请求。
+- `services/generated` 自动生成，禁止手改。
+- `services/api.ts` 面向页面提供稳定业务函数，避免页面直接依赖生成方法名。
+
+## 8. 异常处理机制
+
+| 场景 | 行为 |
+| --- | --- |
+| 404 未知路由 | 展示 NotFoundPage，提供返回解析页和任务页 |
+| 401 未登录/登录失效 | 清理 token，跳转 `/auth`；pending URL 仍可恢复 |
+| 403 无权限 | 展示 ForbiddenState，提供返回任务页 |
+| 422 输入错误 | 展示在表单附近，文案优先使用后端 `error.message` |
+| 429 限流 | 展示“请求太频繁，请稍后再试” |
+| 5xx/网络错误 | 展示 ErrorState，提供重试 |
+| 空任务 | EmptyState 引导去解析页 |
+| 空报告 | EmptyState 提示暂无可导出的报告 |
+| 空 AI 摘要 | 轻量提示 AI 摘要暂不可用 |
+
+API 错误统一通过 `normalizeApiError(error)` 转换为 `{ code, message, details }`。页面和组件只消费规范化错误，不直接解析 axios 原始结构。
+
+## 9. OpenAPI 生成 API 文件
+
+后端 FastAPI 作为接口契约来源：
+
+- Swagger UI：`http://localhost:8000/docs`
+- ReDoc：`http://localhost:8000/redoc`
+- OpenAPI JSON：`http://localhost:8000/openapi.json`
+
+前端生成流程：
+
+```text
+video-server /openapi.json
+        ↓
+npm run api:generate
+        ↓
+src/services/generated/
+        ↓
+src/services/request.ts
+        ↓
+src/services/api.ts
+        ↓
+pages/features
+```
+
+建议使用 Vite 友好的 OpenAPI codegen，例如 `@hey-api/openapi-ts`。它只用于生成 TypeScript client，不改变项目框架。
+
+脚本建议：
+
+- `npm run api:generate`：从 `VITE_OPENAPI_URL` 或默认 `http://localhost:8000/openapi.json` 生成 API client。
+- `npm run api:check`：CI 中校验生成文件是否与 OpenAPI schema 同步。
+
+验收边界：
+
+- 本地后端启动后 `/docs` 和 `/openapi.json` 可访问。
+- 生成文件放在 `src/services/generated/`。
+- 生成文件禁止手改。
+- 页面不新增散落 axios 请求。
+- 手写 `src/lib/api.ts` 逐步迁移到 `src/services/api.ts`，不要求一次删除所有旧入口。
+
+## 10. 测试策略
+
+所有实现继续遵循 Red -> Green -> Refactor。
+
+组件/单元测试：
+
+- 顶部导航四入口和 active 状态。
+- `/workbench` 重定向 `/tasks`。
+- 报告入口跳转 `/tasks?state=SUCCEEDED` 并选中已完成。
+- 账号页展示资料和额度。
+- 401 清 token 并跳转登录。
+- 404 页面展示返回操作。
+- 任务页桌面列表核心字段和移动卡片核心字段。
+- OpenAPI generated API 外层业务封装和错误归一化。
+
+E2E：
+
+- 首页解析到任务详情。
+- 未登录 pending URL 恢复。
+- 报告入口筛选已完成任务。
+- 未知路径展示 404。
+
+验证命令：
+
+- `npm test`
+- `npm run build`
+- `npm run test:e2e`
+- `npm run api:generate`
+- `npm run api:check`
+
+本地启动：
+
+- `npm run dev`
+- `http://localhost:5173/`
+
+## 11. 任务拆分建议
+
+本设计拆成 4 个 feature PR：
+
+1. SaaS Layout Shell：顶部布局、路由命名、PageContainer、404。
+2. Tasks/Reports/Account：任务页响应式、报告入口、账号额度页。
+3. Error States：统一异常组件、401/403/429/5xx 错误处理。
+4. OpenAPI Generated API：后端 OpenAPI 契约检查、前端生成 API、业务封装迁移基线。
+
+每个 PR 必须有对应小 issue、红绿测试证据和 code review 检查项。
+
+## 12. 风险与边界
+
+- OpenAPI 生成可能产生较长方法名，页面不得直接依赖生成命名，应通过业务封装隔离。
+- FastAPI OpenAPI schema 中部分 response model 若缺失，会影响生成质量，需要后端 issue 配合修正。
+- `/tasks` 替代 `/workbench` 需要兼容旧路由，不能破坏已有链接。
+- 报告入口复用任务筛选，不能虚构独立报告中心。
+- 账号页只能展示后端已有字段，不做前端虚拟额度。
+- 本阶段不做主题编辑器、复杂仪表盘、团队管理、计费订阅。
+
+## 13. 自审记录
+
+- Placeholder scan：无 TBD/TODO 占位。
+- Consistency：路由、导航、报告入口和任务拆分保持一致。
+- Scope：聚焦前端 SaaS 布局、异常机制和 API 契约生成，不进入无后端支撑的商业化模块。
+- Ambiguity：明确保留 RadixUI，不引入 antd/Umi；明确 Vite 默认 5173；明确报告入口不是独立报告中心。
+
+## 14. 变更记录
+
+| 日期 | 作者 | 版本 | 变更说明 |
+| --- | --- | --- | --- |
+| 2026-05-23 | StephenQiu30 | 0.1.0 | 初始化 SaaS 顶部布局、异常机制与 OpenAPI API 生成设计 |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -25,3 +25,4 @@ downstream:
 
 - 仅存放架构与设计决策文档。
 - 约定前端从 `src/lib/api.ts` 与 `@tanstack/react-query` 统一发起 API。
+- `03-saas-layout-api-generated-redesign.md` 定义 M3 SaaS 顶部布局、异常状态和 OpenAPI API 生成方案。

--- a/docs/plans/07-saas-layout-api-generated-issues.md
+++ b/docs/plans/07-saas-layout-api-generated-issues.md
@@ -45,17 +45,47 @@ downstream:
 
 | PR 组 | 仓库 | Issues | 说明 |
 | --- | --- | --- | --- |
-| PR-A | video-web | M3-W1 ~ M3-W4 | SaaS layout shell、路由、PageContainer、404 |
-| PR-B | video-web | M3-W5 ~ M3-W8 | 任务页、报告入口、账号页、响应式 |
-| PR-C | video-web | M3-W9 ~ M3-W11 | 异常状态、错误归一化、401/403/429/5xx |
-| PR-D | video-web | M3-W12 ~ M3-W15 | OpenAPI 生成 API、业务封装迁移、生成校验 |
-| PR-E | video-server | M3-S1 ~ M3-S3 | Swagger/OpenAPI 契约确认、导出脚本或文档、schema 缺口检查 |
+| PR-A | video-web | #55, #56, #57, #58 | SaaS layout shell、路由、PageContainer、404 |
+| PR-B | video-web | #59, #60, #61, #62 | 任务页、报告入口、账号页、响应式 |
+| PR-C | video-web | #63, #64, #65 | 异常状态、错误归一化、401/403/429/5xx |
+| PR-D | video-web | #66, #67, #68, #69 | OpenAPI 生成 API、业务封装迁移、生成校验 |
+| PR-E | video-server | #49, #50, #51 | Swagger/OpenAPI 契约确认、导出脚本或文档、schema 缺口检查 |
 
 PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的 OpenAPI 契约结论。
 
-## 4. video-web issues
+## 4. GitHub issue 映射
 
-### M3-W1 `[P1][frontend][layout] SaaS 顶部导航与 AppLayout 基线`
+### 4.1 video-web
+
+| 编号 | 标题 | PR 组 |
+| --- | --- | --- |
+| #55 | `[P1][frontend][layout] SaaS 顶部导航与 AppLayout 基线` | PR-A |
+| #56 | `[P1][frontend][layout] PageContainer 与 PageHeader 统一页面骨架` | PR-A |
+| #57 | `[P1][frontend][route] /tasks 路由替代 /workbench 并保留兼容重定向` | PR-A |
+| #58 | `[P1][frontend][state] 404 NotFoundPage 与未知路由回退` | PR-A |
+| #59 | `[P1][frontend][tasks] 任务页桌面列表与移动卡片响应式` | PR-B |
+| #60 | `[P1][frontend][report] 顶部报告入口跳转已完成任务筛选` | PR-B |
+| #61 | `[P1][frontend][account] 账号页展示用户资料与额度` | PR-B |
+| #62 | `[P1][frontend][parser] 解析页适配新 PageContainer 与 SaaS 视觉节奏` | PR-B |
+| #63 | `[P1][frontend][errors] Empty/Error/Loading/Forbidden 状态组件` | PR-C |
+| #64 | `[P1][frontend][api-contract] normalizeApiError 与 429/5xx 文案` | PR-C |
+| #65 | `[P1][frontend][auth] 401 统一清 token 并跳转登录` | PR-C |
+| #66 | `[P1][frontend][api-generated] OpenAPI 生成工具与目录基线` | PR-D |
+| #67 | `[P1][frontend][api-generated] request.ts 统一 baseURL/token/错误处理` | PR-D |
+| #68 | `[P1][frontend][api-generated] services/api.ts 业务封装迁移基线` | PR-D |
+| #69 | `[P1][frontend][ci] api:check 与生成文件同步校验` | PR-D |
+
+### 4.2 video-server
+
+| 编号 | 标题 | PR 组 |
+| --- | --- | --- |
+| #49 | `[P1][backend][api-contract] Swagger/OpenAPI 本地契约验收` | PR-E |
+| #50 | `[P1][backend][api-contract] OpenAPI response model 缺口检查` | PR-E |
+| #51 | `[P1][backend][docs] OpenAPI 导出与前端生成协作说明` | PR-E |
+
+## 5. video-web issues
+
+### M3-W1 #55 `[P1][frontend][layout] SaaS 顶部导航与 AppLayout 基线`
 
 - Epic：`epic:saas-layout`
 - 类型：`type:frontend`, `type:ui`, `type:architecture`
@@ -69,7 +99,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
   - 未登录/已登录账号区测试通过。
   - 不引入 antd/Umi。
 
-### M3-W2 `[P1][frontend][layout] PageContainer 与 PageHeader 统一页面骨架`
+### M3-W2 #56 `[P1][frontend][layout] PageContainer 与 PageHeader 统一页面骨架`
 
 - Epic：`epic:saas-layout`
 - 类型：`type:frontend`, `type:ui`
@@ -82,7 +112,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
   - 页面标题、描述、右侧操作测试覆盖。
   - 页面不再使用单个大卡片承载整页。
 
-### M3-W3 `[P1][frontend][route] /tasks 路由替代 /workbench 并保留兼容重定向`
+### M3-W3 #57 `[P1][frontend][route] /tasks 路由替代 /workbench 并保留兼容重定向`
 
 - Epic：`epic:saas-layout`
 - 类型：`type:frontend`, `type:core`
@@ -95,7 +125,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
   - `/workbench` 兼容重定向测试通过。
   - 未登录访问 `/tasks` 仍跳转 `/auth`。
 
-### M3-W4 `[P1][frontend][state] 404 NotFoundPage 与未知路由回退`
+### M3-W4 #58 `[P1][frontend][state] 404 NotFoundPage 与未知路由回退`
 
 - Epic：`epic:error-states`
 - 类型：`type:frontend`, `type:ui`
@@ -107,7 +137,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
   - 单测覆盖未知路由。
   - E2E 覆盖 `/unknown-path`。
 
-### M3-W5 `[P1][frontend][tasks] 任务页桌面列表与移动卡片响应式`
+### M3-W5 #59 `[P1][frontend][tasks] 任务页桌面列表与移动卡片响应式`
 
 - Epic：`epic:task-experience`
 - 类型：`type:frontend`, `type:ui`, `type:core`
@@ -120,7 +150,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
   - 核心字段：标题、状态、进度、格式、更新时间、详情入口。
   - 不在列表中堆叠下载/PDF 复杂操作。
 
-### M3-W6 `[P1][frontend][report] 顶部报告入口跳转已完成任务筛选`
+### M3-W6 #60 `[P1][frontend][report] 顶部报告入口跳转已完成任务筛选`
 
 - Epic：`epic:task-experience`
 - 类型：`type:frontend`, `type:report`, `type:core`
@@ -132,7 +162,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
   - 已完成筛选 E2E 通过。
   - 空报告状态文案为“暂无可导出的报告”。
 
-### M3-W7 `[P1][frontend][account] 账号页展示用户资料与额度`
+### M3-W7 #61 `[P1][frontend][account] 账号页展示用户资料与额度`
 
 - Epic：`epic:account-quota`
 - 类型：`type:frontend`, `type:auth`, `type:ui`
@@ -145,7 +175,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
   - 展示邮箱、显示名、任务额度、并发额度、最大文件大小、存储额度、保留时间。
   - 未登录访问跳转 `/auth`。
 
-### M3-W8 `[P1][frontend][parser] 解析页适配新 PageContainer 与 SaaS 视觉节奏`
+### M3-W8 #62 `[P1][frontend][parser] 解析页适配新 PageContainer 与 SaaS 视觉节奏`
 
 - Epic：`epic:conversion-parser`
 - 类型：`type:frontend`, `type:ui`
@@ -158,7 +188,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
   - pending URL 现有测试继续通过。
   - 解析、格式选择、创建任务链路不回退。
 
-### M3-W9 `[P1][frontend][errors] Empty/Error/Loading/Forbidden 状态组件`
+### M3-W9 #63 `[P1][frontend][errors] Empty/Error/Loading/Forbidden 状态组件`
 
 - Epic：`epic:error-states`
 - 类型：`type:frontend`, `type:ui`
@@ -171,7 +201,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
 - 验收：
   - 任务空态、报告空态、详情错误态复用统一组件。
 
-### M3-W10 `[P1][frontend][api-contract] normalizeApiError 与 429/5xx 文案`
+### M3-W10 #64 `[P1][frontend][api-contract] normalizeApiError 与 429/5xx 文案`
 
 - Epic：`epic:error-states`
 - 类型：`type:frontend`, `type:data`, `type:api-contract`
@@ -183,7 +213,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
   - 单测覆盖后端统一错误 envelope。
   - 页面不直接解析 axios 原始错误。
 
-### M3-W11 `[P1][frontend][auth] 401 统一清 token 并跳转登录`
+### M3-W11 #65 `[P1][frontend][auth] 401 统一清 token 并跳转登录`
 
 - Epic：`epic:error-states`
 - 类型：`type:frontend`, `type:auth`, `type:data`
@@ -195,7 +225,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
   - 401 后 localStorage token 被清理。
   - 页面跳转 `/auth`。
 
-### M3-W12 `[P1][frontend][api-generated] OpenAPI 生成工具与目录基线`
+### M3-W12 #66 `[P1][frontend][api-generated] OpenAPI 生成工具与目录基线`
 
 - Epic：`epic:api-generated`
 - 类型：`type:frontend`, `type:data`, `type:api-contract`, `type:devops`
@@ -208,7 +238,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
   - 可从 `http://localhost:8000/openapi.json` 生成 client。
   - generated 目录禁止手改的说明写入文档。
 
-### M3-W13 `[P1][frontend][api-generated] request.ts 统一 baseURL/token/错误处理`
+### M3-W13 #67 `[P1][frontend][api-generated] request.ts 统一 baseURL/token/错误处理`
 
 - Epic：`epic:api-generated`
 - 类型：`type:frontend`, `type:data`
@@ -221,7 +251,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
   - 单测覆盖 token header。
   - 单测覆盖 401 行为。
 
-### M3-W14 `[P1][frontend][api-generated] services/api.ts 业务封装迁移基线`
+### M3-W14 #68 `[P1][frontend][api-generated] services/api.ts 业务封装迁移基线`
 
 - Epic：`epic:api-generated`
 - 类型：`type:frontend`, `type:data`, `type:api-contract`
@@ -234,7 +264,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
   - 页面不直接依赖 generated 方法名。
   - 现有 API 测试迁移或保持兼容。
 
-### M3-W15 `[P1][frontend][ci] api:check 与生成文件同步校验`
+### M3-W15 #69 `[P1][frontend][ci] api:check 与生成文件同步校验`
 
 - Epic：`epic:api-generated`
 - 类型：`type:frontend`, `type:ci`, `type:devops`
@@ -246,9 +276,9 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
   - schema 与 generated 不一致时校验失败。
   - README 或 operations 文档说明联调方式。
 
-## 5. video-server issues
+## 6. video-server issues
 
-### M3-S1 `[P1][backend][api-contract] Swagger/OpenAPI 本地契约验收`
+### M3-S1 #49 `[P1][backend][api-contract] Swagger/OpenAPI 本地契约验收`
 
 - Epic：`epic:openapi-contract`
 - 类型：`type:backend`, `type:api-contract`, `type:docs`
@@ -260,7 +290,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
   - `curl http://localhost:8000/openapi.json` 可获得 JSON。
   - Swagger UI 可访问或有明确配置说明。
 
-### M3-S2 `[P1][backend][api-contract] OpenAPI response model 缺口检查`
+### M3-S2 #50 `[P1][backend][api-contract] OpenAPI response model 缺口检查`
 
 - Epic：`epic:openapi-contract`
 - 类型：`type:backend`, `type:api-contract`, `type:test`
@@ -271,7 +301,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
 - 验收：
   - 前端 codegen 不因关键接口缺少 schema 失败。
 
-### M3-S3 `[P1][backend][docs] OpenAPI 导出与前端生成协作说明`
+### M3-S3 #51 `[P1][backend][docs] OpenAPI 导出与前端生成协作说明`
 
 - Epic：`epic:openapi-contract`
 - 类型：`type:backend`, `type:docs`, `type:api-contract`
@@ -282,7 +312,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
 - 验收：
   - 文档包含本地端口 `8000` 与前端默认端口 `5173`。
 
-## 6. 任务自审
+## 7. 任务自审
 
 ### 6.1 是否过度设计
 
@@ -317,7 +347,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
 - generated API 与业务封装分层，避免页面绑定生成器命名。
 - Vite 默认 5173 写入验收标准，避免启动地址漂移。
 
-## 7. GitHub issue 标签建议
+## 8. GitHub issue 标签建议
 
 需要新增标签：
 
@@ -346,7 +376,7 @@ PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的
 - `type:report`
 - `agent:ready`
 
-## 8. issue 创建后的确认项
+## 9. issue 创建后的确认项
 
 - 所有 issue 都绑定 milestone。
 - 所有 issue 至少包含 priority、type、workflow、agent:ready。

--- a/docs/plans/07-saas-layout-api-generated-issues.md
+++ b/docs/plans/07-saas-layout-api-generated-issues.md
@@ -1,0 +1,355 @@
+---
+layer: plans
+doc_no: "PLAN-007"
+audience:
+  - PM
+  - Dev
+  - QA
+feature_area: saas-layout-openapi
+purpose: "拆分 video-web SaaS 顶部布局、响应式任务体验、异常状态和 OpenAPI 生成 API 的小粒度 GitHub issues。"
+canonical_path: "docs/plans/07-saas-layout-api-generated-issues.md"
+status: draft
+version: "0.1.0"
+owner: "StephenQiu30"
+inputs:
+  - "docs/design/03-saas-layout-api-generated-redesign.md"
+outputs:
+  - "M3 issue 拆分与 PR 分组"
+triggers:
+  - "开始 M3 SaaS 布局与 API 契约生成工作"
+downstream:
+  - "GitHub Issues"
+  - "docs/acceptance/02-issue-pr-映射.md"
+---
+
+# M3 SaaS 布局与 OpenAPI API 生成任务拆分
+
+## 1. 执行原则
+
+- 不直接进入实现；先完成 issue、milestone、labels 和任务自审。
+- 每个功能 issue 都要求 Red -> Green -> Refactor。
+- 提交顺序继续遵循 `test:m3-*` -> `impl:m3-*` -> `refactor:m3-*` -> `docs:m3-*`。
+- 一个完整 feature 一个 PR，不做一次修改一个 PR。
+- 前端本地调试地址固定为 Vite 默认 `http://localhost:5173/`。
+- 设计参考 Ant Design Pro 布局范式，但不引入 antd、Umi 或 Pro Components。
+- 正式文档只写入 `docs/design`、`docs/plans`、`docs/acceptance`、`docs/operations`，不写 `docs/superpowers`。
+
+## 2. Milestone
+
+| 仓库 | Milestone | 目标 |
+| --- | --- | --- |
+| `video-web` | `M3 SaaS 顶部布局与 OpenAPI API 生成` | 完成前端 SaaS 顶部布局、响应式任务体验、异常机制和 generated API 基线 |
+| `video-server` | `M3 OpenAPI 契约文档支撑` | 确认 Swagger/OpenAPI 可用、补齐前端生成 API 所需契约说明和缺口 |
+
+## 3. PR 分组
+
+| PR 组 | 仓库 | Issues | 说明 |
+| --- | --- | --- | --- |
+| PR-A | video-web | M3-W1 ~ M3-W4 | SaaS layout shell、路由、PageContainer、404 |
+| PR-B | video-web | M3-W5 ~ M3-W8 | 任务页、报告入口、账号页、响应式 |
+| PR-C | video-web | M3-W9 ~ M3-W11 | 异常状态、错误归一化、401/403/429/5xx |
+| PR-D | video-web | M3-W12 ~ M3-W15 | OpenAPI 生成 API、业务封装迁移、生成校验 |
+| PR-E | video-server | M3-S1 ~ M3-S3 | Swagger/OpenAPI 契约确认、导出脚本或文档、schema 缺口检查 |
+
+PR 顺序建议：PR-E 可与 PR-A 并行准备，但 PR-D 必须依赖 PR-E 的 OpenAPI 契约结论。
+
+## 4. video-web issues
+
+### M3-W1 `[P1][frontend][layout] SaaS 顶部导航与 AppLayout 基线`
+
+- Epic：`epic:saas-layout`
+- 类型：`type:frontend`, `type:ui`, `type:architecture`
+- Workflow：`workflow:tdd`, `workflow:review`
+- 产出：
+  - `AppLayout` 组件。
+  - 顶部导航：解析、任务、报告、账号。
+  - 登录态账号区。
+- 验收：
+  - 导航 active 状态测试通过。
+  - 未登录/已登录账号区测试通过。
+  - 不引入 antd/Umi。
+
+### M3-W2 `[P1][frontend][layout] PageContainer 与 PageHeader 统一页面骨架`
+
+- Epic：`epic:saas-layout`
+- 类型：`type:frontend`, `type:ui`
+- Workflow：`workflow:tdd`
+- 产出：
+  - `PageContainer`。
+  - `PageHeader`。
+  - 解析、任务、详情、账号页统一标题区。
+- 验收：
+  - 页面标题、描述、右侧操作测试覆盖。
+  - 页面不再使用单个大卡片承载整页。
+
+### M3-W3 `[P1][frontend][route] /tasks 路由替代 /workbench 并保留兼容重定向`
+
+- Epic：`epic:saas-layout`
+- 类型：`type:frontend`, `type:core`
+- Workflow：`workflow:tdd`, `workflow:e2e`
+- 产出：
+  - `/tasks` 任务页。
+  - `/workbench` 重定向到 `/tasks`。
+  - 旧 E2E 路径更新。
+- 验收：
+  - `/workbench` 兼容重定向测试通过。
+  - 未登录访问 `/tasks` 仍跳转 `/auth`。
+
+### M3-W4 `[P1][frontend][state] 404 NotFoundPage 与未知路由回退`
+
+- Epic：`epic:error-states`
+- 类型：`type:frontend`, `type:ui`
+- Workflow：`workflow:tdd`, `workflow:e2e`
+- 产出：
+  - `NotFoundPage`。
+  - 未知路由展示返回解析页和任务页。
+- 验收：
+  - 单测覆盖未知路由。
+  - E2E 覆盖 `/unknown-path`。
+
+### M3-W5 `[P1][frontend][tasks] 任务页桌面列表与移动卡片响应式`
+
+- Epic：`epic:task-experience`
+- 类型：`type:frontend`, `type:ui`, `type:core`
+- Workflow：`workflow:tdd`
+- 产出：
+  - `TaskList`。
+  - `TaskMobileCard`。
+  - 桌面列表、移动卡片 CSS。
+- 验收：
+  - 核心字段：标题、状态、进度、格式、更新时间、详情入口。
+  - 不在列表中堆叠下载/PDF 复杂操作。
+
+### M3-W6 `[P1][frontend][report] 顶部报告入口跳转已完成任务筛选`
+
+- Epic：`epic:task-experience`
+- 类型：`type:frontend`, `type:report`, `type:core`
+- Workflow：`workflow:tdd`, `workflow:e2e`
+- 产出：
+  - 顶部“报告”链接跳转 `/tasks?state=SUCCEEDED`。
+  - 任务页读取 query 并选中已完成筛选。
+- 验收：
+  - 已完成筛选 E2E 通过。
+  - 空报告状态文案为“暂无可导出的报告”。
+
+### M3-W7 `[P1][frontend][account] 账号页展示用户资料与额度`
+
+- Epic：`epic:account-quota`
+- 类型：`type:frontend`, `type:auth`, `type:ui`
+- Workflow：`workflow:tdd`
+- 产出：
+  - `/account`。
+  - `AccountSummary`。
+  - `QuotaList`。
+- 验收：
+  - 展示邮箱、显示名、任务额度、并发额度、最大文件大小、存储额度、保留时间。
+  - 未登录访问跳转 `/auth`。
+
+### M3-W8 `[P1][frontend][parser] 解析页适配新 PageContainer 与 SaaS 视觉节奏`
+
+- Epic：`epic:conversion-parser`
+- 类型：`type:frontend`, `type:ui`
+- Workflow：`workflow:tdd`
+- 产出：
+  - `ParserPanel`。
+  - `ParseResultPanel`。
+  - 首页使用新页面骨架。
+- 验收：
+  - pending URL 现有测试继续通过。
+  - 解析、格式选择、创建任务链路不回退。
+
+### M3-W9 `[P1][frontend][errors] Empty/Error/Loading/Forbidden 状态组件`
+
+- Epic：`epic:error-states`
+- 类型：`type:frontend`, `type:ui`
+- Workflow：`workflow:tdd`
+- 产出：
+  - `EmptyState`。
+  - `ErrorState`。
+  - `LoadingState`。
+  - `ForbiddenState`。
+- 验收：
+  - 任务空态、报告空态、详情错误态复用统一组件。
+
+### M3-W10 `[P1][frontend][api-contract] normalizeApiError 与 429/5xx 文案`
+
+- Epic：`epic:error-states`
+- 类型：`type:frontend`, `type:data`, `type:api-contract`
+- Workflow：`workflow:tdd`
+- 产出：
+  - `normalizeApiError(error)`。
+  - 422、429、5xx、网络错误文案归一化。
+- 验收：
+  - 单测覆盖后端统一错误 envelope。
+  - 页面不直接解析 axios 原始错误。
+
+### M3-W11 `[P1][frontend][auth] 401 统一清 token 并跳转登录`
+
+- Epic：`epic:error-states`
+- 类型：`type:frontend`, `type:auth`, `type:data`
+- Workflow：`workflow:tdd`, `workflow:e2e`
+- 产出：
+  - API 或 auth hook 统一处理 401。
+  - 保留 pending URL 恢复逻辑。
+- 验收：
+  - 401 后 localStorage token 被清理。
+  - 页面跳转 `/auth`。
+
+### M3-W12 `[P1][frontend][api-generated] OpenAPI 生成工具与目录基线`
+
+- Epic：`epic:api-generated`
+- 类型：`type:frontend`, `type:data`, `type:api-contract`, `type:devops`
+- Workflow：`workflow:tdd`, `workflow:review`
+- 产出：
+  - `src/services/generated/`。
+  - `npm run api:generate`。
+  - 生成文件说明。
+- 验收：
+  - 可从 `http://localhost:8000/openapi.json` 生成 client。
+  - generated 目录禁止手改的说明写入文档。
+
+### M3-W13 `[P1][frontend][api-generated] request.ts 统一 baseURL/token/错误处理`
+
+- Epic：`epic:api-generated`
+- 类型：`type:frontend`, `type:data`
+- Workflow：`workflow:tdd`
+- 产出：
+  - `src/services/request.ts`。
+  - token 注入。
+  - 401 和错误归一化接入点。
+- 验收：
+  - 单测覆盖 token header。
+  - 单测覆盖 401 行为。
+
+### M3-W14 `[P1][frontend][api-generated] services/api.ts 业务封装迁移基线`
+
+- Epic：`epic:api-generated`
+- 类型：`type:frontend`, `type:data`, `type:api-contract`
+- Workflow：`workflow:tdd`
+- 产出：
+  - `src/services/api.ts`。
+  - 解析、任务、详情、下载、PDF、me 的业务封装。
+  - 逐步替代 `src/lib/api.ts`。
+- 验收：
+  - 页面不直接依赖 generated 方法名。
+  - 现有 API 测试迁移或保持兼容。
+
+### M3-W15 `[P1][frontend][ci] api:check 与生成文件同步校验`
+
+- Epic：`epic:api-generated`
+- 类型：`type:frontend`, `type:ci`, `type:devops`
+- Workflow：`workflow:tdd`, `workflow:review`
+- 产出：
+  - `npm run api:check`。
+  - CI 或本地校验 generated API 未同步。
+- 验收：
+  - schema 与 generated 不一致时校验失败。
+  - README 或 operations 文档说明联调方式。
+
+## 5. video-server issues
+
+### M3-S1 `[P1][backend][api-contract] Swagger/OpenAPI 本地契约验收`
+
+- Epic：`epic:openapi-contract`
+- 类型：`type:backend`, `type:api-contract`, `type:docs`
+- Workflow：`workflow:review`
+- 产出：
+  - 记录 `/docs`、`/redoc`、`/openapi.json` 的本地验收方式。
+  - 若生产环境禁用 docs，需要明确本地/生产差异。
+- 验收：
+  - `curl http://localhost:8000/openapi.json` 可获得 JSON。
+  - Swagger UI 可访问或有明确配置说明。
+
+### M3-S2 `[P1][backend][api-contract] OpenAPI response model 缺口检查`
+
+- Epic：`epic:openapi-contract`
+- 类型：`type:backend`, `type:api-contract`, `type:test`
+- Workflow：`workflow:tdd`, `workflow:review`
+- 产出：
+  - 检查解析、任务、详情、下载、PDF、me、错误响应是否有可生成 schema。
+  - 缺失 response model 的接口列出修正项。
+- 验收：
+  - 前端 codegen 不因关键接口缺少 schema 失败。
+
+### M3-S3 `[P1][backend][docs] OpenAPI 导出与前端生成协作说明`
+
+- Epic：`epic:openapi-contract`
+- 类型：`type:backend`, `type:docs`, `type:api-contract`
+- Workflow：`workflow:review`
+- 产出：
+  - 后端 docs 说明如何导出 `openapi.json`。
+  - 前端 `npm run api:generate` 的依赖说明。
+- 验收：
+  - 文档包含本地端口 `8000` 与前端默认端口 `5173`。
+
+## 6. 任务自审
+
+### 6.1 是否过度设计
+
+- 未加入计费、团队、通知、复杂报告中心、复杂仪表盘。
+- 报告入口复用已完成任务筛选，符合真实功能。
+- 账号页只展示已有用户字段和额度，不做设置中心。
+
+### 6.2 是否有后端依赖未说明
+
+- OpenAPI 生成依赖后端 `/openapi.json`。
+- PDF 报告依赖已有 `/api/tasks/{task_id}/pdf`。
+- 账号额度依赖 `/api/auth/me` 已返回字段。
+- 如果 OpenAPI schema 缺 response model，由 M3-S2 先发现并修正。
+
+### 6.3 是否可 TDD
+
+- 每个前端功能 issue 都有明确组件/路由/API 行为可写失败测试。
+- E2E 仅覆盖关键路径：pending URL、报告筛选、404、解析到详情。
+- 后端 OpenAPI issue 以契约测试和文档验收为主，不混入前端实现。
+
+### 6.4 PR 分组是否合理
+
+- PR-A 先改壳层，避免后续页面重复套布局。
+- PR-B 再改任务/报告/账号业务页面。
+- PR-C 统一异常机制，避免页面散落错误处理。
+- PR-D 最后接 codegen，避免布局重构和 API 生成互相干扰。
+- PR-E 可先行确认后端契约，降低 PR-D 风险。
+
+### 6.5 风险控制
+
+- `/workbench` 兼容重定向避免旧链接失效。
+- generated API 与业务封装分层，避免页面绑定生成器命名。
+- Vite 默认 5173 写入验收标准，避免启动地址漂移。
+
+## 7. GitHub issue 标签建议
+
+需要新增标签：
+
+- `epic:saas-layout`
+- `epic:error-states`
+- `epic:account-quota`
+- `epic:api-generated`
+- `epic:openapi-contract`
+
+复用已有标签：
+
+- `priority:P1`
+- `workflow:tdd`
+- `workflow:e2e`
+- `workflow:review`
+- `type:frontend`
+- `type:backend`
+- `type:ui`
+- `type:core`
+- `type:data`
+- `type:api-contract`
+- `type:docs`
+- `type:devops`
+- `type:ci`
+- `type:auth`
+- `type:report`
+- `agent:ready`
+
+## 8. issue 创建后的确认项
+
+- 所有 issue 都绑定 milestone。
+- 所有 issue 至少包含 priority、type、workflow、agent:ready。
+- 所有 issue 标题可独立理解，不依赖上下文。
+- issue body 包含产出和验收标准。
+- 不创建实现分支，不启动实现工作。

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -27,3 +27,4 @@ downstream:
 
 - 仅存放长期计划文档（执行计划、里程碑、任务拆解）。
 - 需要可执行拆分：每个任务包含 `epic / 优先级 / 类型 / 产出 / 验收`。
+- `07-saas-layout-api-generated-issues.md` 拆分 M3 SaaS 顶部布局、响应式任务体验、异常状态和 OpenAPI API 生成 issues。


### PR DESCRIPTION
## 变更说明
- 新增 M3 SaaS 顶部布局、异常机制与 OpenAPI API 生成设计文档。
- 新增 M3 小粒度 issue 拆分、PR 分组、任务自审和风险控制文档。
- 回填已创建 GitHub issue 编号：video-web #55-#69，video-server #49-#51。

## 执行边界
- 本 PR 仅包含 docs，不进入实现。
- 后续实现需按文档中的 PR-A ~ PR-E 顺序拆分执行。
- 所有功能 issue 继续遵循 Red -> Green -> Refactor。

## 验证
- `git diff --check`
- 已核对 issue 均绑定 milestone、priority/type/workflow/agent 标签。

## Agent Usage
- 使用 Superpowers brainstorming 流程完成需求澄清、设计收敛、任务拆分和自审。
