### PR TITLE
feat:m3-01 SaaS布局壳层与路由基线

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -10,9 +10,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 18px;
   border-bottom: 1px solid var(--border);
-  padding: 18px 24px;
+  padding: 14px 24px;
   background: rgba(255, 255, 255, 0.86);
+  backdrop-filter: blur(14px);
   position: sticky;
   top: 0;
   z-index: 5;
@@ -23,6 +25,9 @@
   flex-direction: column;
   gap: 2px;
   font-weight: 600;
+  color: #0f2238;
+  min-width: max-content;
+  text-decoration: none;
 }
 
 .brand-sub {
@@ -32,12 +37,15 @@
 
 .header-nav {
   display: flex;
-  gap: 12px;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  gap: 6px;
   font-size: 14px;
 }
 
 .header-nav a {
-  padding: 8px 12px;
+  padding: 8px 14px;
   border-radius: 8px;
   color: #0f2238;
   text-decoration: none;
@@ -46,6 +54,19 @@
 .header-nav a.active {
   background: #e8f2ff;
   color: #0b63ce;
+}
+
+.account-entry {
+  min-width: 132px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.account-status {
+  color: #334b68;
+  font-size: 13px;
 }
 
 .app-main {
@@ -66,11 +87,45 @@
   width: 100%;
 }
 
+.page-container {
+  width: 100%;
+  display: grid;
+  gap: 18px;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 18px;
+  padding: 4px 0 2px;
+}
+
+.page-header h1 {
+  margin: 0;
+  color: #0f2238;
+  font-size: 30px;
+  line-height: 1.2;
+  letter-spacing: 0;
+}
+
+.page-header p {
+  margin: 8px 0 0;
+  color: #4d6078;
+  line-height: 1.6;
+}
+
+.page-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
 .hero-parser {
   display: grid;
   gap: 18px;
   margin-bottom: 18px;
-  padding: 26px 0 8px;
+  padding: 18px 0 8px;
 }
 
 .hero-copy {
@@ -80,7 +135,7 @@
 }
 
 .hero-copy h1 {
-  font-size: clamp(34px, 5vw, 56px);
+  font-size: 48px;
   line-height: 1.04;
   letter-spacing: 0;
 }
@@ -269,6 +324,17 @@
   color: #60758f;
 }
 
+.not-found-page {
+  min-height: 50vh;
+  align-content: center;
+}
+
+.not-found-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
 .task-meta-row {
   display: flex;
   gap: 14px;
@@ -359,6 +425,40 @@
 }
 
 @media (max-width: 760px) {
+  .app-header {
+    align-items: stretch;
+    flex-direction: column;
+    padding: 12px 16px;
+  }
+
+  .brand {
+    min-width: 0;
+  }
+
+  .header-nav {
+    width: 100%;
+    overflow-x: auto;
+    justify-content: flex-start;
+    padding-bottom: 2px;
+  }
+
+  .account-entry {
+    min-width: 0;
+    justify-content: flex-start;
+  }
+
+  .page-header {
+    display: grid;
+  }
+
+  .page-header h1 {
+    font-size: 26px;
+  }
+
+  .hero-copy h1 {
+    font-size: 36px;
+  }
+
   .parse-input-wrap {
     display: grid;
   }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -18,10 +18,29 @@ describe('路由鉴权', () => {
     window.sessionStorage.clear()
   })
 
-  it('未登录访问工作台会重定向到登录页', async () => {
-    renderWithProviders(<App />, { initialEntries: ['/workbench'] })
+  it('顶部布局提供解析、任务、报告、账号入口', async () => {
+    renderWithProviders(<App />)
+
+    expect(await screen.findByRole('banner', { name: '应用顶部栏' })).toBeInTheDocument()
+    expect(screen.getByRole('navigation', { name: '主导航' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '解析' })).toHaveAttribute('href', '/')
+    expect(screen.getByRole('link', { name: '任务' })).toHaveAttribute('href', '/tasks')
+    expect(screen.getByRole('link', { name: '报告' })).toHaveAttribute('href', '/tasks?state=SUCCEEDED')
+    expect(screen.getByRole('link', { name: '账号' })).toHaveAttribute('href', '/account')
+  })
+
+  it('未登录访问任务页会重定向到登录页', async () => {
+    renderWithProviders(<App />, { initialEntries: ['/tasks'] })
 
     expect(await screen.findByRole('heading', { name: '登录' })).toBeInTheDocument()
+  })
+
+  it('旧工作台地址在登录后兼容跳转到任务页', async () => {
+    window.localStorage.setItem('video_web_access_token', 'unit-token')
+
+    renderWithProviders(<App />, { initialEntries: ['/workbench'] })
+
+    expect(await screen.findByRole('heading', { name: '下载任务' })).toBeInTheDocument()
   })
 
   it('授权页访问时会展示回跳按钮', async () => {
@@ -43,5 +62,19 @@ describe('路由鉴权', () => {
 
     expect(await screen.findByRole('heading', { name: '万能视频解析下载器' })).toBeInTheDocument()
     expect(screen.getByLabelText('视频链接')).toHaveValue('https://v.douyin.com/pending')
+  })
+
+  it('登录回跳没有 pending URL 时进入任务页', async () => {
+    renderWithProviders(<App />, { initialEntries: ['/auth?token=unit-token'] })
+
+    expect(await screen.findByRole('heading', { name: '下载任务' })).toBeInTheDocument()
+  })
+
+  it('未知路由展示 404 页面并提供返回入口', async () => {
+    renderWithProviders(<App />, { initialEntries: ['/missing-page'] })
+
+    expect(await screen.findByRole('heading', { name: '页面不存在' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '返回解析页' })).toHaveAttribute('href', '/')
+    expect(screen.getByRole('link', { name: '查看任务' })).toHaveAttribute('href', '/tasks')
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,30 +1,15 @@
-import { Navigate, NavLink, Route, Routes, useLocation } from 'react-router-dom'
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
 
+import { AccountPage } from './pages/AccountPage'
 import { AuthPage } from './pages/AuthPage'
 import { HomePage } from './pages/HomePage'
+import { NotFoundPage } from './pages/NotFoundPage'
 import { TaskDetailPage } from './pages/TaskDetailPage'
 import { WorkbenchPage } from './pages/WorkbenchPage'
+import { AppLayout } from './components/layout/AppLayout'
 import { useAuth } from './contexts/auth'
 
 import './App.css'
-
-function AppHeader() {
-  return (
-    <header className="app-header">
-      <div className="brand">
-        <span>万能视频下载器</span>
-        <span className="brand-sub">解析 · 队列 · AI 报告</span>
-      </div>
-      <nav className="header-nav">
-        <NavLink to="/" end>
-          解析
-        </NavLink>
-        <NavLink to="/workbench">工作台</NavLink>
-        <NavLink to="/auth">登录 / 注册</NavLink>
-      </nav>
-    </header>
-  )
-}
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
   const { token } = useAuth()
@@ -38,33 +23,45 @@ function RequireAuth({ children }: { children: React.ReactNode }) {
 
 function App() {
   return (
-    <div className="app-shell">
-      <AppHeader />
-      <main className="app-main">
-        <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/auth" element={<AuthPage />} />
-          <Route
-            path="/workbench"
-            element={
-              <RequireAuth>
-                <WorkbenchPage />
-              </RequireAuth>
-            }
-          />
-          <Route
-            path="/tasks/:taskId"
-            element={
-              <RequireAuth>
-                <TaskDetailPage />
-              </RequireAuth>
-            }
-          />
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
-      </main>
-      <footer className="app-footer">MVP API-First 视频下载器 · video-server + video-web</footer>
-    </div>
+    <AppLayout>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/auth" element={<AuthPage />} />
+        <Route
+          path="/tasks"
+          element={
+            <RequireAuth>
+              <WorkbenchPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/workbench"
+          element={
+            <RequireAuth>
+              <Navigate to="/tasks" replace />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/tasks/:taskId"
+          element={
+            <RequireAuth>
+              <TaskDetailPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/account"
+          element={
+            <RequireAuth>
+              <AccountPage />
+            </RequireAuth>
+          }
+        />
+        <Route path="*" element={<NotFoundPage />} />
+      </Routes>
+    </AppLayout>
   )
 }
 

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,0 +1,73 @@
+import { Link, NavLink, useLocation } from 'react-router-dom'
+
+import { useAuth } from '../../contexts/auth'
+import { Button } from '../ui/button'
+
+type AppLayoutProps = {
+  children: React.ReactNode
+}
+
+type NavItem = {
+  label: string
+  to: string
+  end?: boolean
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { label: '解析', to: '/', end: true },
+  { label: '任务', to: '/tasks' },
+  { label: '报告', to: '/tasks?state=SUCCEEDED' },
+  { label: '账号', to: '/account' },
+]
+
+function isReportActive(pathname: string, search: string) {
+  return pathname === '/tasks' && search.includes('state=SUCCEEDED')
+}
+
+export function AppLayout({ children }: AppLayoutProps) {
+  const { token, setToken } = useAuth()
+  const location = useLocation()
+
+  return (
+    <div className="app-shell">
+      <header className="app-header" aria-label="应用顶部栏">
+        <Link className="brand" to="/">
+          <span>万能视频下载器</span>
+          <span className="brand-sub">解析 · 队列 · AI 报告</span>
+        </Link>
+        <nav className="header-nav" aria-label="主导航">
+          {NAV_ITEMS.map((item) => (
+            <NavLink
+              key={item.label}
+              to={item.to}
+              end={item.end}
+              className={({ isActive }) => {
+                const active =
+                  item.label === '报告' ? isReportActive(location.pathname, location.search) : isActive && item.label !== '报告'
+                return active ? 'active' : ''
+              }}
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </nav>
+        <div className="account-entry">
+          {token ? (
+            <>
+              <span className="account-status">已登录</span>
+              <Button type="button" size="sm" variant="outline" onClick={() => setToken(null)}>
+                退出
+              </Button>
+            </>
+          ) : (
+            <Button asChild size="sm">
+              <Link to="/auth">登录</Link>
+            </Button>
+          )}
+        </div>
+      </header>
+      <main className="app-main">{children}</main>
+      <footer className="app-footer">API-First 视频下载器 · video-server + video-web</footer>
+    </div>
+  )
+}

--- a/src/components/layout/PageContainer.tsx
+++ b/src/components/layout/PageContainer.tsx
@@ -1,0 +1,18 @@
+import { PageHeader } from './PageHeader'
+
+type PageContainerProps = {
+  children: React.ReactNode
+  title?: string
+  description?: string
+  actions?: React.ReactNode
+  className?: string
+}
+
+export function PageContainer({ children, title, description, actions, className = '' }: PageContainerProps) {
+  return (
+    <section className={`page-container ${className}`}>
+      {title && <PageHeader title={title} description={description} actions={actions} />}
+      {children}
+    </section>
+  )
+}

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -1,0 +1,17 @@
+type PageHeaderProps = {
+  title: string
+  description?: string
+  actions?: React.ReactNode
+}
+
+export function PageHeader({ title, description, actions }: PageHeaderProps) {
+  return (
+    <div className="page-header">
+      <div>
+        <h1>{title}</h1>
+        {description && <p>{description}</p>}
+      </div>
+      {actions && <div className="page-actions">{actions}</div>}
+    </div>
+  )
+}

--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -1,0 +1,18 @@
+import { PageContainer } from '../components/layout/PageContainer'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
+
+export function AccountPage() {
+  return (
+    <PageContainer title="账号" description="查看当前登录状态、任务额度与账号设置。">
+      <Card>
+        <CardHeader>
+          <CardTitle>账号概览</CardTitle>
+          <CardDescription>账号资料与额度详情会在后续任务中接入真实接口。</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="state-text">当前账号已登录，可以创建解析任务并查看下载记录。</p>
+        </CardContent>
+      </Card>
+    </PageContainer>
+  )
+}

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '../contexts/auth'
 import { getGitHubAuthorizeUrl } from '../lib/api'
 import { hasPendingUrl } from '../lib/pending-url'
+import { PageContainer } from '../components/layout/PageContainer'
 import { Button } from '../components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card'
 
@@ -18,7 +19,7 @@ export function AuthPage() {
   const { setToken, token } = useAuth()
   const callbackToken = useSearchToken()
   const isProcessing = Boolean(token || callbackToken)
-  const nextPath = hasPendingUrl() ? '/' : '/workbench'
+  const nextPath = hasPendingUrl() ? '/' : '/tasks'
 
   useEffect(() => {
     if (token) {
@@ -36,10 +37,10 @@ export function AuthPage() {
   }, [callbackToken, setToken, token, navigate, nextPath])
 
   return (
-    <section className="page">
+    <PageContainer title="登录" description="登录后可以创建解析任务、查看下载队列并导出报告。">
       <Card>
         <CardHeader>
-          <CardTitle>登录</CardTitle>
+          <CardTitle>GitHub 授权</CardTitle>
         </CardHeader>
         <CardContent>
             {!isProcessing ? (
@@ -54,6 +55,6 @@ export function AuthPage() {
           )}
         </CardContent>
       </Card>
-    </section>
+    </PageContainer>
   )
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -5,6 +5,7 @@ import { useMutation } from '@tanstack/react-query'
 
 import { parseVideo, createTask, getGitHubAuthorizeUrl, type ParseResult } from '../lib/api'
 import { useAuth } from '../contexts/auth'
+import { PageContainer } from '../components/layout/PageContainer'
 import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
@@ -108,7 +109,7 @@ export function HomePage() {
   const onCreate = () => createMutation.mutate()
 
   return (
-    <section className="page">
+    <PageContainer className="parser-page">
       <div className="hero-parser">
         <div className="hero-copy">
           <Badge>国内短视频优先 · B站/抖音/快手/小红书</Badge>
@@ -208,6 +209,6 @@ export function HomePage() {
           )}
         </CardContent>
       </Card>
-    </section>
+    </PageContainer>
   )
 }

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router-dom'
+
+import { PageContainer } from '../components/layout/PageContainer'
+import { Button } from '../components/ui/button'
+
+export function NotFoundPage() {
+  return (
+    <PageContainer
+      title="页面不存在"
+      description="当前地址没有匹配的页面，请回到解析入口或任务列表继续。"
+      className="not-found-page"
+    >
+      <div className="not-found-actions">
+        <Button asChild>
+          <Link to="/">返回解析页</Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link to="/tasks">查看任务</Link>
+        </Button>
+      </div>
+    </PageContainer>
+  )
+}

--- a/src/pages/TaskDetailPage.tsx
+++ b/src/pages/TaskDetailPage.tsx
@@ -12,6 +12,7 @@ import {
   type TaskEventRead,
 } from '../lib/api'
 import { useAuth } from '../contexts/auth'
+import { PageContainer } from '../components/layout/PageContainer'
 import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
@@ -114,8 +115,20 @@ export function TaskDetailPage() {
     return events.slice(0, 30)
   }, [events])
 
-  if (isLoading) return <p className="page">任务加载中...</p>
-  if (isError) return <p className="error-text">加载失败：{error ? parseErrorMessage(error) : '未知错误'}</p>
+  if (isLoading) {
+    return (
+      <PageContainer title="任务详情">
+        <p>任务加载中...</p>
+      </PageContainer>
+    )
+  }
+  if (isError) {
+    return (
+      <PageContainer title="任务详情">
+        <p className="error-text">加载失败：{error ? parseErrorMessage(error) : '未知错误'}</p>
+      </PageContainer>
+    )
+  }
   if (!task) return null
 
   const canCancel = task.state === 'QUEUED' || task.state === 'STARTING' || task.state === 'DOWNLOADING'
@@ -125,7 +138,7 @@ export function TaskDetailPage() {
   const mindmap = parseMindmap(task.ai_mindmap)
 
   return (
-    <section className="page">
+    <PageContainer title="任务详情" description={`任务 ID：${task.id}`}>
       <Card>
         <CardHeader>
           <CardTitle>{task.title || task.source_url}</CardTitle>
@@ -138,8 +151,8 @@ export function TaskDetailPage() {
             <Progress value={task.progress} />
           </div>
           <div className="task-actions">
-            <Button type="button" onClick={() => navigate('/workbench')} variant="outline">
-              返回工作台
+            <Button type="button" onClick={() => navigate('/tasks')} variant="outline">
+              返回任务
             </Button>
             <Button type="button" onClick={() => cancelMut.mutate()} disabled={!canCancel || cancelMut.isPending}>
               {cancelMut.isPending ? '取消中...' : '取消'}
@@ -208,6 +221,6 @@ export function TaskDetailPage() {
           </ul>
         </CardContent>
       </Card>
-    </section>
+    </PageContainer>
   )
 }

--- a/src/pages/WorkbenchPage.tsx
+++ b/src/pages/WorkbenchPage.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 
 import { listTasks, type TaskRead } from '../lib/api'
 import { useAuth } from '../contexts/auth'
+import { PageContainer } from '../components/layout/PageContainer'
 import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
@@ -80,10 +81,10 @@ export function WorkbenchPage() {
   const visibleTasks = useMemo(() => tasks.filter((task) => matchesFilter(task, filter)), [filter, tasks])
 
   return (
-    <section className="page">
+    <PageContainer title="下载任务" description="查看解析后的下载队列、任务状态与报告出口。">
       <Card>
         <CardHeader>
-          <CardTitle>下载工作台</CardTitle>
+          <CardTitle>任务列表</CardTitle>
           <CardDescription>展示任务列表与实时状态</CardDescription>
         </CardHeader>
         <CardContent>
@@ -136,6 +137,6 @@ export function WorkbenchPage() {
           </div>
         </CardContent>
       </Card>
-    </section>
+    </PageContainer>
   )
 }

--- a/tests/e2e/auth-to-workbench.spec.ts
+++ b/tests/e2e/auth-to-workbench.spec.ts
@@ -1,12 +1,12 @@
 import { expect, test } from '@playwright/test'
 
-test('未登录时访问 workbench 重定向到 auth', async ({ page }) => {
-  await page.goto('/workbench')
+test('未登录时访问 tasks 重定向到 auth', async ({ page }) => {
+  await page.goto('/tasks')
   await expect(page).toHaveURL(/\/auth/)
   await expect(page.getByRole('heading', { name: '登录' })).toBeVisible()
 })
 
-test('带 token 回跳到 auth 后自动进入 workbench', async ({ page }) => {
+test('带 token 回跳到 auth 后自动进入 tasks', async ({ page }) => {
   await page.route('**/api/tasks*', (route) =>
     route.fulfill({
       status: 200,
@@ -16,6 +16,12 @@ test('带 token 回跳到 auth 后自动进入 workbench', async ({ page }) => {
   )
 
   await page.goto('/auth?token=e2e-token')
-  await expect(page).toHaveURL(/\/workbench/)
-  await expect(page.getByText('下载工作台')).toBeVisible()
+  await expect(page).toHaveURL(/\/tasks/)
+  await expect(page.getByRole('heading', { name: '下载任务' })).toBeVisible()
+})
+
+test('未知路由展示 404 页面', async ({ page }) => {
+  await page.goto('/not-found-here')
+  await expect(page.getByRole('heading', { name: '页面不存在' })).toBeVisible()
+  await expect(page.getByRole('link', { name: '返回解析页' })).toBeVisible()
 })

--- a/tests/e2e/parse-create-detail.spec.ts
+++ b/tests/e2e/parse-create-detail.spec.ts
@@ -130,8 +130,8 @@ test('解析分享链接并创建任务后可进入详情页获取下载链接',
     })
   })
 
-  await page.goto('/workbench')
-  await expect(page.getByRole('heading', { name: '下载工作台' })).toBeVisible()
+  await page.goto('/tasks')
+  await expect(page.getByRole('heading', { name: '下载任务' })).toBeVisible()
 
   await page.goto('/')
   await page.getByLabel('视频链接').fill('https://v.douyin.com/abc')


### PR DESCRIPTION
## 变更摘要
- 建立 AppLayout 顶部导航：解析、任务、报告、账号
- 新增 PageContainer/PageHeader 页面骨架，迁移首页、登录、任务、详情页
- 将 /tasks 作为任务页主入口，/workbench 保留登录后兼容重定向
- 新增 404 NotFoundPage 与 E2E 覆盖

## TDD 与验证
- 红灯：新增 App 路由/布局/404 单测和 E2E，确认旧实现失败
- 绿灯：实现布局与路由后通过验证
- npm run lint
- npm test
- npm run build
- npm run test:e2e

Closes #55
Closes #56
Closes #57
Closes #58