### PR TITLE
feat:m3-02 任务报告账号与解析体验增强

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -293,6 +293,12 @@
   background: #ffffff;
 }
 
+.task-card-link:hover .task-card,
+.task-card-link:focus-visible .task-card {
+  border-color: #88bfff;
+  box-shadow: 0 8px 20px rgba(31, 95, 167, 0.08);
+}
+
 .task-thumb {
   width: 100%;
   aspect-ratio: 16 / 9;
@@ -320,8 +326,90 @@
   font-size: 13px;
 }
 
+.task-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2px 16px;
+}
+
+.task-detail-text {
+  display: inline-flex;
+  width: fit-content;
+  margin-top: 10px;
+  color: #0b63ce;
+  font-size: 13px;
+  font-weight: 600;
+}
+
 .empty-state {
   color: #60758f;
+}
+
+.report-empty {
+  display: grid;
+  gap: 8px;
+  margin: 8px 0 14px;
+}
+
+.report-empty a {
+  color: #0b63ce;
+}
+
+.account-page-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.account-summary {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+}
+
+.account-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 999px;
+  border: 1px solid #d9e6ff;
+}
+
+.account-title-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.account-title-row h2 {
+  margin: 0;
+  font-size: 22px;
+  letter-spacing: 0;
+}
+
+.quota-list {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.quota-item {
+  border: 1px solid #dbe7f6;
+  border-radius: 8px;
+  padding: 12px;
+  background: #f8fbff;
+}
+
+.quota-item dt {
+  color: #60758f;
+  font-size: 13px;
+}
+
+.quota-item dd {
+  margin: 6px 0 0;
+  color: #0f2238;
+  font-size: 18px;
+  font-weight: 700;
 }
 
 .not-found-page {
@@ -465,5 +553,14 @@
 
   .capability-strip {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .task-fields,
+  .quota-list {
+    grid-template-columns: 1fr;
+  }
+
+  .account-summary {
+    align-items: flex-start;
   }
 }

--- a/src/components/account/AccountSummary.tsx
+++ b/src/components/account/AccountSummary.tsx
@@ -1,0 +1,24 @@
+import type { UserRead } from '../../lib/api'
+import { Badge } from '../ui/badge'
+
+type AccountSummaryProps = {
+  user: UserRead
+}
+
+export function AccountSummary({ user }: AccountSummaryProps) {
+  const name = user.display_name || user.email
+
+  return (
+    <div className="account-summary">
+      {user.avatar_url && <img className="account-avatar" src={user.avatar_url} alt={`${name} 头像`} />}
+      <div>
+        <div className="account-title-row">
+          <h2>{name}</h2>
+          <Badge>{user.is_active ? '正常' : '已停用'}</Badge>
+        </div>
+        <p>{user.email}</p>
+        <p className="task-meta">GitHub ID：{user.github_id || '未绑定'}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/account/QuotaList.tsx
+++ b/src/components/account/QuotaList.tsx
@@ -1,0 +1,33 @@
+import type { UserRead } from '../../lib/api'
+
+type QuotaListProps = {
+  user: UserRead
+}
+
+function formatBytes(value: number) {
+  const gb = value / 1024 / 1024 / 1024
+  if (gb >= 1) return `${Number.isInteger(gb) ? gb : gb.toFixed(1)} GB`
+  const mb = value / 1024 / 1024
+  return `${Number.isInteger(mb) ? mb : mb.toFixed(1)} MB`
+}
+
+export function QuotaList({ user }: QuotaListProps) {
+  const items = [
+    { label: '每日任务额度', value: `${user.daily_task_quota} 次` },
+    { label: '并发额度', value: `${user.concurrent_task_quota} 个任务` },
+    { label: '最大文件大小', value: formatBytes(user.max_file_size_bytes) },
+    { label: '存储额度', value: formatBytes(user.storage_quota_bytes) },
+    { label: '文件保留时间', value: `${user.file_retention_hours} 小时` },
+  ]
+
+  return (
+    <dl className="quota-list">
+      {items.map((item) => (
+        <div key={item.label} className="quota-item">
+          <dt>{item.label}</dt>
+          <dd>{item.value}</dd>
+        </div>
+      ))}
+    </dl>
+  )
+}

--- a/src/components/parser/ParserPanel.tsx
+++ b/src/components/parser/ParserPanel.tsx
@@ -1,0 +1,25 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card'
+
+type ParserPanelProps = {
+  children: React.ReactNode
+}
+
+export function ParserPanel({ children }: ParserPanelProps) {
+  return (
+    <Card className="parser-panel">
+      <CardHeader>
+        <CardTitle>首屏解析器</CardTitle>
+        <CardDescription>支持登录后解析并创建下载任务，解析结果会保留标题、封面、平台与可用格式。</CardDescription>
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  )
+}
+
+export function ParseResultPanel({ children }: ParserPanelProps) {
+  return (
+    <div className="parse-result" role="region" aria-label="解析结果">
+      {children}
+    </div>
+  )
+}

--- a/src/components/tasks/TaskList.tsx
+++ b/src/components/tasks/TaskList.tsx
@@ -1,0 +1,87 @@
+import { Link } from 'react-router-dom'
+
+import type { TaskRead } from '../../lib/api'
+import { Badge } from '../ui/badge'
+import { Progress } from '../ui/progress'
+
+type TaskListProps = {
+  tasks: TaskRead[]
+}
+
+const STATE_TAG: Record<string, string> = {
+  PENDING: 'pending',
+  QUEUED: 'pending',
+  DOWNLOADING: 'running',
+  SUCCEEDED: 'done',
+  FAILED: 'failed',
+  CANCELED: 'canceled',
+}
+
+function stateBadge(state: string) {
+  return <Badge className={`state-${STATE_TAG[state] ?? 'pending'}`}>{state}</Badge>
+}
+
+function formatDate(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString()
+}
+
+function formatDuration(seconds?: number | null) {
+  if (!seconds) return '未知'
+  const minutes = Math.floor(seconds / 60)
+  const rest = seconds % 60
+  return `${String(minutes).padStart(2, '0')}:${String(rest).padStart(2, '0')}`
+}
+
+function aiStatusLabel(status?: string | null) {
+  if (status === 'SUCCEEDED') return '已生成'
+  if (status === 'FAILED') return '失败'
+  if (status === 'PENDING') return '等待处理'
+  if (status === 'PROCESSING') return '生成中'
+  return '未开始'
+}
+
+function taskTitle(task: TaskRead) {
+  return task.title || task.source_url
+}
+
+export function TaskMobileCard({ task }: { task: TaskRead }) {
+  const title = taskTitle(task)
+
+  return (
+    <article className="task-card task-mobile-card">
+      {task.cover_url && <img className="task-thumb" src={task.cover_url} alt={title} />}
+      <div className="task-title-row">
+        <h4>{title}</h4>
+        {stateBadge(task.state)}
+      </div>
+      <div className="task-fields">
+        <p className="task-meta">格式：{task.format_label || task.format_id || '默认'}</p>
+        <p className="task-meta">时长：{formatDuration(task.duration_seconds)}</p>
+        <p className="task-meta">AI：{aiStatusLabel(task.ai_status)}</p>
+        <p className="task-meta">报告：{task.state === 'SUCCEEDED' ? '可导出' : '待完成'}</p>
+        <p className="task-meta">更新时间：{formatDate(task.updated_at)}</p>
+      </div>
+      <Progress value={task.progress} />
+      <span className="task-detail-text">详情</span>
+    </article>
+  )
+}
+
+export function TaskList({ tasks }: TaskListProps) {
+  return (
+    <div className="task-list">
+      {tasks.map((task) => (
+        <Link
+          to={`/tasks/${task.id}`}
+          key={task.id}
+          className="task-card-link"
+          aria-label={`查看详情：${taskTitle(task)}`}
+        >
+          <TaskMobileCard task={task} />
+        </Link>
+      ))}
+    </div>
+  )
+}

--- a/src/pages/AccountPage.test.tsx
+++ b/src/pages/AccountPage.test.tsx
@@ -1,0 +1,54 @@
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getCurrentUser } from '../lib/api'
+import { renderWithProviders } from '../test/test-utils'
+import { AccountPage } from './AccountPage'
+
+vi.mock('../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../lib/api')>('../lib/api')
+  return {
+    ...actual,
+    getCurrentUser: vi.fn(),
+  }
+})
+
+describe('AccountPage', () => {
+  beforeEach(() => {
+    window.localStorage.setItem('video_web_access_token', 'unit-test-token')
+    vi.clearAllMocks()
+  })
+
+  it('展示当前用户资料与额度信息', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValueOnce({
+      id: 1,
+      email: 'demo@example.com',
+      github_id: '10001',
+      avatar_url: 'https://cdn.example.com/avatar.png',
+      display_name: 'Demo User',
+      is_active: true,
+      is_admin: false,
+      daily_task_quota: 20,
+      concurrent_task_quota: 3,
+      max_file_size_bytes: 2 * 1024 * 1024 * 1024,
+      storage_quota_bytes: 50 * 1024 * 1024 * 1024,
+      file_retention_hours: 72,
+      created_at: '2026-01-01T00:00:00Z',
+    })
+
+    renderWithProviders(<AccountPage />)
+
+    expect(await screen.findByText('Demo User')).toBeInTheDocument()
+    expect(screen.getByText('demo@example.com')).toBeInTheDocument()
+    expect(screen.getByText('每日任务额度')).toBeInTheDocument()
+    expect(screen.getByText('20 次')).toBeInTheDocument()
+    expect(screen.getByText('并发额度')).toBeInTheDocument()
+    expect(screen.getByText('3 个任务')).toBeInTheDocument()
+    expect(screen.getByText('最大文件大小')).toBeInTheDocument()
+    expect(screen.getByText('2 GB')).toBeInTheDocument()
+    expect(screen.getByText('存储额度')).toBeInTheDocument()
+    expect(screen.getByText('50 GB')).toBeInTheDocument()
+    expect(screen.getByText('文件保留时间')).toBeInTheDocument()
+    expect(screen.getByText('72 小时')).toBeInTheDocument()
+  })
+})

--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -1,16 +1,36 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { AccountSummary } from '../components/account/AccountSummary'
+import { QuotaList } from '../components/account/QuotaList'
 import { PageContainer } from '../components/layout/PageContainer'
+import { useAuth } from '../contexts/auth'
+import { getCurrentUser } from '../lib/api'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
 
 export function AccountPage() {
+  const { token } = useAuth()
+  const { data: user, isLoading, isError, error } = useQuery({
+    queryKey: ['current-user', token],
+    queryFn: () => getCurrentUser(token),
+    enabled: Boolean(token),
+  })
+
   return (
     <PageContainer title="账号" description="查看当前登录状态、任务额度与账号设置。">
       <Card>
         <CardHeader>
           <CardTitle>账号概览</CardTitle>
-          <CardDescription>账号资料与额度详情会在后续任务中接入真实接口。</CardDescription>
+          <CardDescription>基础资料与下载任务额度来自后端账号接口。</CardDescription>
         </CardHeader>
         <CardContent>
-          <p className="state-text">当前账号已登录，可以创建解析任务并查看下载记录。</p>
+          {isLoading && <p className="state-text">账号加载中...</p>}
+          {isError && <p className="error-text">{error instanceof Error ? error.message : '账号加载失败'}</p>}
+          {user && (
+            <div className="account-page-grid">
+              <AccountSummary user={user} />
+              <QuotaList user={user} />
+            </div>
+          )}
         </CardContent>
       </Card>
     </PageContainer>

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -27,6 +27,7 @@ describe('HomePage', () => {
     renderWithProviders(<HomePage />)
 
     expect(screen.getByRole('heading', { name: '万能视频解析下载器' })).toBeInTheDocument()
+    expect(screen.getByRole('form', { name: '视频解析表单' })).toBeInTheDocument()
     expect(screen.getByText('格式选择')).toBeInTheDocument()
     expect(screen.getByText('任务队列')).toBeInTheDocument()
     expect(screen.getByText('AI 摘要')).toBeInTheDocument()
@@ -101,6 +102,7 @@ describe('HomePage', () => {
     await user.click(screen.getByRole('button', { name: '解析视频' }))
 
     expect(await screen.findByText('解析完成，选择规格后可创建下载任务')).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: '解析结果' })).toBeInTheDocument()
     expect(screen.getByText('douyin')).toBeInTheDocument()
     expect(screen.getByAltText('demo title')).toHaveAttribute('src', 'https://cdn.example.com/cover.jpg')
     expect(parseVideoMock).toHaveBeenCalledWith('unit-test-token', 'https://v.douyin.com/test')

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -6,9 +6,9 @@ import { useMutation } from '@tanstack/react-query'
 import { parseVideo, createTask, getGitHubAuthorizeUrl, type ParseResult } from '../lib/api'
 import { useAuth } from '../contexts/auth'
 import { PageContainer } from '../components/layout/PageContainer'
+import { ParserPanel, ParseResultPanel } from '../components/parser/ParserPanel'
 import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
 import { Input } from '../components/ui/input'
 import { readPendingUrl, savePendingUrl } from '../lib/pending-url'
 
@@ -124,13 +124,8 @@ export function HomePage() {
         </div>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>首屏解析器</CardTitle>
-          <CardDescription>支持登录后解析并创建下载任务，解析结果会保留标题、封面、平台与可用格式。</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form className="parse-form" onSubmit={onSubmit}>
+      <ParserPanel>
+          <form className="parse-form" aria-label="视频解析表单" onSubmit={onSubmit}>
             <label className="form-label" htmlFor="video-url">
               视频链接
             </label>
@@ -169,7 +164,7 @@ export function HomePage() {
             </p>
           )}
           {parseResult && (
-            <div className="parse-result">
+            <ParseResultPanel>
               {parseResult.cover_url && (
                 <img className="result-cover" src={parseResult.cover_url} alt={parseResult.title || '视频封面'} />
               )}
@@ -205,10 +200,9 @@ export function HomePage() {
                   </div>
                 </div>
               )}
-            </div>
+            </ParseResultPanel>
           )}
-        </CardContent>
-      </Card>
+      </ParserPanel>
     </PageContainer>
   )
 }

--- a/src/pages/WorkbenchPage.test.tsx
+++ b/src/pages/WorkbenchPage.test.tsx
@@ -201,6 +201,94 @@ describe('WorkbenchPage', () => {
 
     expect(screen.queryByText('正在下载的视频')).not.toBeInTheDocument()
     expect(screen.getByText('已完成的视频')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '查看详情：已完成的视频' })).toHaveAttribute('href', '/tasks/t-done')
+  })
+
+  it('报告入口 query 会默认选中已完成任务筛选', async () => {
+    vi.mocked(listTasks).mockResolvedValueOnce([
+      {
+        id: 't-running',
+        source_url: 'https://v.douyin.com/running',
+        title: '正在下载的视频',
+        state: 'DOWNLOADING',
+        progress: 42,
+        format_id: '1080',
+        format_label: '1080P MP4',
+        failure_code: null,
+        failure_reason: null,
+        output_filename: null,
+        object_size: null,
+        expires_at: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        attempt_no: 1,
+        is_latest_attempt: true,
+        retry_of_task_id: null,
+        ai_summary: null,
+        ai_status: 'PENDING',
+        ai_error: null,
+      },
+      {
+        id: 't-done',
+        source_url: 'https://www.bilibili.com/video/BV1xx411c7mD',
+        title: '已完成的视频',
+        state: 'SUCCEEDED',
+        progress: 100,
+        format_id: '720',
+        format_label: '720P MP4',
+        failure_code: null,
+        failure_reason: null,
+        output_filename: 'done.mp4',
+        object_size: 1200000,
+        expires_at: '2026-01-02T00:00:00Z',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        attempt_no: 1,
+        is_latest_attempt: true,
+        retry_of_task_id: null,
+        ai_summary: '已生成摘要',
+        ai_status: 'SUCCEEDED',
+        ai_error: null,
+      },
+    ])
+
+    renderWithProviders(<WorkbenchPage />, { initialEntries: ['/tasks?state=SUCCEEDED'] })
+
+    expect(await screen.findByText('已完成的视频')).toBeInTheDocument()
+    expect(screen.queryByText('正在下载的视频')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '已完成' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('报告入口没有已完成任务时展示报告空态', async () => {
+    vi.mocked(listTasks).mockResolvedValueOnce([
+      {
+        id: 't-running',
+        source_url: 'https://v.douyin.com/running',
+        title: '正在下载的视频',
+        state: 'DOWNLOADING',
+        progress: 42,
+        format_id: '1080',
+        format_label: '1080P MP4',
+        failure_code: null,
+        failure_reason: null,
+        output_filename: null,
+        object_size: null,
+        expires_at: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        attempt_no: 1,
+        is_latest_attempt: true,
+        retry_of_task_id: null,
+        ai_summary: null,
+        ai_status: 'PENDING',
+        ai_error: null,
+      },
+    ])
+
+    renderWithProviders(<WorkbenchPage />, { initialEntries: ['/tasks?state=SUCCEEDED'] })
+
+    expect(await screen.findByText('暂无可导出的报告')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '返回解析页' })).toHaveAttribute('href', '/')
   })
 
   it('错误态能展示任务列表请求异常', async () => {

--- a/src/pages/WorkbenchPage.tsx
+++ b/src/pages/WorkbenchPage.tsx
@@ -1,23 +1,13 @@
-import { Link } from 'react-router-dom'
-import { useMemo, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 
 import { listTasks, type TaskRead } from '../lib/api'
 import { useAuth } from '../contexts/auth'
 import { PageContainer } from '../components/layout/PageContainer'
-import { Badge } from '../components/ui/badge'
+import { TaskList } from '../components/tasks/TaskList'
 import { Button } from '../components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
-import { Progress } from '../components/ui/progress'
-
-const STATE_TAG: Record<string, string> = {
-  PENDING: 'pending',
-  QUEUED: 'pending',
-  DOWNLOADING: 'running',
-  SUCCEEDED: 'done',
-  FAILED: 'failed',
-  CANCELED: 'canceled',
-}
 
 const FILTERS = [
   { key: 'ALL', label: '全部' },
@@ -28,40 +18,24 @@ const FILTERS = [
 
 type TaskFilter = (typeof FILTERS)[number]['key']
 
-function stateBadge(state: string) {
-  return <Badge className={`state-${STATE_TAG[state] ?? 'pending'}`}>{state}</Badge>
-}
-
-function formatDate(value: string) {
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return value
-  return date.toLocaleString()
-}
-
-function formatDuration(seconds?: number | null) {
-  if (!seconds) return '未知'
-  const minutes = Math.floor(seconds / 60)
-  const rest = seconds % 60
-  return `${String(minutes).padStart(2, '0')}:${String(rest).padStart(2, '0')}`
-}
-
-function aiStatusLabel(status?: string | null) {
-  if (status === 'SUCCEEDED') return '已生成'
-  if (status === 'FAILED') return '失败'
-  if (status === 'PENDING') return '等待处理'
-  if (status === 'PROCESSING') return '生成中'
-  return '未开始'
-}
-
 function matchesFilter(task: TaskRead, filter: TaskFilter) {
   if (filter === 'ALL') return true
   if (filter === 'RUNNING') return ['PENDING', 'QUEUED', 'STARTING', 'DOWNLOADING', 'MERGING', 'PROCESSING'].includes(task.state)
   return task.state === filter
 }
 
+function filterFromSearch(searchParams: URLSearchParams): TaskFilter {
+  const state = searchParams.get('state')
+  if (state === 'SUCCEEDED') return 'SUCCEEDED'
+  if (state === 'FAILED') return 'FAILED'
+  if (state === 'RUNNING') return 'RUNNING'
+  return 'ALL'
+}
+
 export function WorkbenchPage() {
   const { token } = useAuth()
-  const [filter, setFilter] = useState<TaskFilter>('ALL')
+  const [searchParams, setSearchParams] = useSearchParams()
+  const filter = filterFromSearch(searchParams)
   const { data: tasks = [], isLoading, isError, error } = useQuery({
     queryKey: ['tasks', token],
     queryFn: () => listTasks(token),
@@ -78,10 +52,27 @@ export function WorkbenchPage() {
     }
   }, [tasks])
 
+  const onFilterChange = (next: TaskFilter) => {
+    if (next === 'ALL') {
+      setSearchParams({})
+      return
+    }
+    setSearchParams({ state: next })
+  }
+
   const visibleTasks = useMemo(() => tasks.filter((task) => matchesFilter(task, filter)), [filter, tasks])
+  const isReportFilter = filter === 'SUCCEEDED'
 
   return (
-    <PageContainer title="下载任务" description="查看解析后的下载队列、任务状态与报告出口。">
+    <PageContainer
+      title="下载任务"
+      description="查看解析后的下载队列、任务状态与报告出口。"
+      actions={
+        <Button asChild variant="outline">
+          <Link to="/">新建解析</Link>
+        </Button>
+      }
+    >
       <Card>
         <CardHeader>
           <CardTitle>任务列表</CardTitle>
@@ -100,8 +91,9 @@ export function WorkbenchPage() {
               <Button
                 key={item.key}
                 type="button"
+                aria-pressed={filter === item.key}
                 variant={filter === item.key ? 'default' : 'outline'}
-                onClick={() => setFilter(item.key)}
+                onClick={() => onFilterChange(item.key)}
               >
                 {item.label}
               </Button>
@@ -112,29 +104,18 @@ export function WorkbenchPage() {
 
           {!isLoading && isError && <p className="error-text">{(error as Error).message}</p>}
 
-          {!isLoading && tasks.length === 0 && !isError && (
+          {!isLoading && tasks.length === 0 && !isError && !isReportFilter && (
             <p className="empty-state">暂无任务，返回首页粘贴链接创建任务</p>
           )}
 
-          <div className="task-list">
-            {visibleTasks.map((task: TaskRead) => (
-              <Link to={`/tasks/${task.id}`} key={task.id} className="task-card-link">
-                <article className="task-card">
-                  {task.cover_url && <img className="task-thumb" src={task.cover_url} alt={task.title || task.source_url} />}
-                  <div className="task-title-row">
-                    <h4>{task.title || task.source_url}</h4>
-                    {stateBadge(task.state)}
-                  </div>
-                  <p className="task-meta">格式：{task.format_label || task.format_id || '默认'}</p>
-                  <p className="task-meta">时长：{formatDuration(task.duration_seconds)}</p>
-                  <p className="task-meta">AI：{aiStatusLabel(task.ai_status)}</p>
-                  <p className="task-meta">报告：{task.state === 'SUCCEEDED' ? '可导出' : '待完成'}</p>
-                  <Progress value={task.progress} />
-                  <p className="task-meta">更新时间：{formatDate(task.updated_at)}</p>
-                </article>
-              </Link>
-            ))}
-          </div>
+          {!isLoading && !isError && isReportFilter && visibleTasks.length === 0 && (
+            <div className="empty-state report-empty">
+              <p>暂无可导出的报告</p>
+              <Link to="/">返回解析页</Link>
+            </div>
+          )}
+
+          <TaskList tasks={visibleTasks} />
         </CardContent>
       </Card>
     </PageContainer>

--- a/tests/e2e/auth-to-workbench.spec.ts
+++ b/tests/e2e/auth-to-workbench.spec.ts
@@ -25,3 +25,65 @@ test('未知路由展示 404 页面', async ({ page }) => {
   await expect(page.getByRole('heading', { name: '页面不存在' })).toBeVisible()
   await expect(page.getByRole('link', { name: '返回解析页' })).toBeVisible()
 })
+
+test('顶部报告入口跳转已完成任务筛选', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('video_web_access_token', 'e2e-token')
+  })
+  await page.route('**/api/tasks*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 't-running',
+          source_url: 'https://v.douyin.com/running',
+          title: '正在下载的视频',
+          state: 'DOWNLOADING',
+          progress: 50,
+          failure_code: null,
+          failure_reason: null,
+          output_filename: null,
+          object_size: null,
+          expires_at: null,
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+          attempt_no: 1,
+          is_latest_attempt: true,
+          retry_of_task_id: null,
+          ai_summary: null,
+          ai_status: null,
+          ai_error: null,
+        },
+        {
+          id: 't-done',
+          source_url: 'https://www.bilibili.com/video/BV1xx411c7mD',
+          title: '已完成的视频',
+          state: 'SUCCEEDED',
+          progress: 100,
+          failure_code: null,
+          failure_reason: null,
+          output_filename: 'done.mp4',
+          object_size: 1000,
+          expires_at: '2026-01-02T00:00:00Z',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+          attempt_no: 1,
+          is_latest_attempt: true,
+          retry_of_task_id: null,
+          ai_summary: '已生成摘要',
+          ai_status: 'SUCCEEDED',
+          ai_error: null,
+        },
+      ]),
+    }),
+  )
+
+  await page.goto('/')
+  await page.getByRole('navigation', { name: '主导航' }).getByRole('link', { name: '报告', exact: true }).click()
+
+  await expect(page).toHaveURL(/\/tasks\?state=SUCCEEDED/)
+  await expect(page.getByText('已完成的视频')).toBeVisible()
+  await expect(page.getByText('正在下载的视频')).toBeHidden()
+  await expect(page.getByRole('button', { name: '已完成' })).toHaveAttribute('aria-pressed', 'true')
+})


### PR DESCRIPTION
## 变更摘要
- 任务页读取 /tasks?state=SUCCEEDED，并将筛选状态作为 URL 派生状态
- 任务列表抽出 TaskList/TaskMobileCard，补充详情入口与核心字段展示
- 报告入口复用已完成任务筛选，并补充空报告状态
- 账号页接入 getCurrentUser，展示资料、任务额度、并发额度、文件大小、存储额度和保留时间
- 解析页抽出 ParserPanel/ParseResultPanel，补齐表单与结果区域语义

## TDD 与验证
- 红灯：补充任务/报告/账号/解析页单测与报告入口 E2E，旧实现失败
- 绿灯：实现后通过完整验证
- npm run lint
- npm test
- npm run build
- npm run test:e2e

Closes #59
Closes #60
Closes #61
Closes #62