### PR TITLE
feat:m3-03 统一异常状态与401处理

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -345,6 +345,43 @@
   color: #60758f;
 }
 
+.state-block {
+  display: grid;
+  gap: 8px;
+  align-content: center;
+  justify-items: start;
+  border: 1px solid #dbe7f6;
+  border-radius: 8px;
+  padding: 18px;
+  background: #f8fbff;
+  color: #334b68;
+}
+
+.state-block strong {
+  color: #0f2238;
+}
+
+.state-block p {
+  margin: 0;
+}
+
+.error-state {
+  border-color: #fed7d7;
+  background: #fff5f5;
+}
+
+.loading-state {
+  grid-template-columns: auto 1fr;
+  align-items: center;
+}
+
+.loading-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #0b63ce;
+}
+
 .report-empty {
   display: grid;
   gap: 8px;

--- a/src/components/states/StateBlocks.test.tsx
+++ b/src/components/states/StateBlocks.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import { EmptyState, ErrorState, ForbiddenState, LoadingState } from './StateBlocks'
+
+describe('StateBlocks', () => {
+  it('渲染统一空态和操作入口', () => {
+    render(
+      <MemoryRouter>
+        <EmptyState title="暂无任务" description="返回解析页创建任务" actionLabel="返回解析页" actionTo="/" />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('status')).toHaveTextContent('暂无任务')
+    expect(screen.getByRole('link', { name: '返回解析页' })).toHaveAttribute('href', '/')
+  })
+
+  it('渲染错误态并支持重试', async () => {
+    const retry = vi.fn()
+    render(<ErrorState title="加载失败" description="网络错误" retryLabel="重试" onRetry={retry} />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent('加载失败')
+    screen.getByRole('button', { name: '重试' }).click()
+    expect(retry).toHaveBeenCalledTimes(1)
+  })
+
+  it('渲染加载态和无权限态', () => {
+    const { rerender } = render(<LoadingState title="任务加载中" />)
+    expect(screen.getByRole('status')).toHaveTextContent('任务加载中')
+
+    rerender(
+      <MemoryRouter>
+        <ForbiddenState />
+      </MemoryRouter>,
+    )
+    expect(screen.getByRole('alert')).toHaveTextContent('没有访问权限')
+    expect(screen.getByRole('link', { name: '返回任务页' })).toHaveAttribute('href', '/tasks')
+  })
+})

--- a/src/components/states/StateBlocks.tsx
+++ b/src/components/states/StateBlocks.tsx
@@ -1,0 +1,66 @@
+import { Link } from 'react-router-dom'
+
+import { Button } from '../ui/button'
+
+type EmptyStateProps = {
+  title: string
+  description?: string
+  actionLabel?: string
+  actionTo?: string
+}
+
+type ErrorStateProps = {
+  title?: string
+  description: string
+  retryLabel?: string
+  onRetry?: () => void
+}
+
+export function EmptyState({ title, description, actionLabel, actionTo }: EmptyStateProps) {
+  return (
+    <div className="state-block empty-state" role="status">
+      <strong>{title}</strong>
+      {description && <p>{description}</p>}
+      {actionLabel && actionTo && (
+        <Button asChild variant="outline">
+          <Link to={actionTo}>{actionLabel}</Link>
+        </Button>
+      )}
+    </div>
+  )
+}
+
+export function LoadingState({ title = '加载中...' }: { title?: string }) {
+  return (
+    <div className="state-block loading-state" role="status">
+      <span className="loading-dot" />
+      <strong>{title}</strong>
+    </div>
+  )
+}
+
+export function ErrorState({ title = '加载失败', description, retryLabel, onRetry }: ErrorStateProps) {
+  return (
+    <div className="state-block error-state" role="alert">
+      <strong>{title}</strong>
+      <p>{description}</p>
+      {retryLabel && onRetry && (
+        <Button type="button" variant="outline" onClick={onRetry}>
+          {retryLabel}
+        </Button>
+      )}
+    </div>
+  )
+}
+
+export function ForbiddenState() {
+  return (
+    <div className="state-block error-state" role="alert">
+      <strong>没有访问权限</strong>
+      <p>当前账号无权访问该内容。</p>
+      <Button asChild variant="outline">
+        <Link to="/tasks">返回任务页</Link>
+      </Button>
+    </div>
+  )
+}

--- a/src/contexts/auth.tsx
+++ b/src/contexts/auth.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable react-refresh/only-export-components */
 
-import { createContext, useContext, useMemo, useState } from 'react'
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
 type AppAuth = {
   token: string | null
   setToken: (next: string | null) => void
 }
 
-const AUTH_KEY = 'video_web_access_token'
+export const AUTH_KEY = 'video_web_access_token'
+export const AUTH_EXPIRED_EVENT = 'video_web_auth_expired'
 
 const AuthContext = createContext<AppAuth | null>(null)
 
@@ -24,6 +25,15 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       window.localStorage.removeItem(AUTH_KEY)
     }
   }
+
+  useEffect(() => {
+    const onAuthExpired = () => {
+      setTokenState(null)
+      window.localStorage.removeItem(AUTH_KEY)
+    }
+    window.addEventListener(AUTH_EXPIRED_EVENT, onAuthExpired)
+    return () => window.removeEventListener(AUTH_EXPIRED_EVENT, onAuthExpired)
+  }, [])
 
   const value = useMemo(() => ({ token, setToken }), [token])
 

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { api, getTaskReportLink } from './api'
+import axios from 'axios'
+
+import { api, getTaskReportLink, normalizeApiError } from './api'
 
 describe('api report contract', () => {
   afterEach(() => {
@@ -24,5 +26,51 @@ describe('api report contract', () => {
       url: 'blob:http://localhost/report',
       expires_in_seconds: 0,
     })
+  })
+})
+
+describe('normalizeApiError', () => {
+  it('优先使用后端统一错误 envelope', () => {
+    const error = new axios.AxiosError('bad request', 'ERR_BAD_REQUEST', undefined, undefined, {
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      headers: {},
+      config: {} as never,
+      data: {
+        error: {
+          code: 'validation_error',
+          message: '请输入有效链接',
+          details: { field: 'url' },
+        },
+      },
+    })
+
+    expect(normalizeApiError(error)).toEqual({
+      code: 'validation_error',
+      message: '请输入有效链接',
+      details: { field: 'url' },
+      status: 422,
+    })
+  })
+
+  it('归一化限流、服务端和网络错误文案', () => {
+    const rateLimit = new axios.AxiosError('rate limited', 'ERR_BAD_REQUEST', undefined, undefined, {
+      status: 429,
+      statusText: 'Too Many Requests',
+      headers: {},
+      config: {} as never,
+      data: {},
+    })
+    const serverError = new axios.AxiosError('server down', 'ERR_BAD_RESPONSE', undefined, undefined, {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: {},
+      config: {} as never,
+      data: {},
+    })
+
+    expect(normalizeApiError(rateLimit).message).toBe('请求太频繁，请稍后再试')
+    expect(normalizeApiError(serverError).message).toBe('服务暂时不可用，请稍后重试')
+    expect(normalizeApiError(new TypeError('Failed to fetch')).message).toBe('网络连接异常，请检查网络后重试')
   })
 })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,7 @@
 import axios from 'axios'
 
+import { AUTH_EXPIRED_EVENT, AUTH_KEY } from '../contexts/auth'
+
 const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000').replace(/\/$/, '')
 
 export const api = axios.create({
@@ -14,6 +16,64 @@ export type ApiError = {
     details?: unknown
   }
 }
+
+export type NormalizedApiError = {
+  code: string
+  message: string
+  details?: unknown
+  status?: number
+}
+
+function isApiErrorEnvelope(data: unknown): data is ApiError {
+  if (!data || typeof data !== 'object') return false
+  const candidate = data as { error?: unknown }
+  if (!candidate.error || typeof candidate.error !== 'object') return false
+  const error = candidate.error as { code?: unknown; message?: unknown }
+  return typeof error.code === 'string' && typeof error.message === 'string'
+}
+
+export function normalizeApiError(error: unknown): NormalizedApiError {
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status
+    const data = error.response?.data
+    if (isApiErrorEnvelope(data)) {
+      return {
+        code: data.error.code,
+        message: data.error.message,
+        details: data.error.details,
+        status,
+      }
+    }
+    if (status === 401) return { code: 'unauthorized', message: '登录已失效，请重新登录', status }
+    if (status === 403) return { code: 'forbidden', message: '没有访问权限', status }
+    if (status === 429) return { code: 'rate_limited', message: '请求太频繁，请稍后再试', status }
+    if (status && status >= 500) return { code: 'server_error', message: '服务暂时不可用，请稍后重试', status }
+    if (!error.response) return { code: 'network_error', message: '网络连接异常，请检查网络后重试' }
+    return { code: 'request_error', message: error.message || '请求失败，请稍后重试', status }
+  }
+
+  if (error instanceof TypeError) {
+    return { code: 'network_error', message: '网络连接异常，请检查网络后重试' }
+  }
+
+  if (error instanceof Error) {
+    return { code: 'unknown_error', message: error.message || '请求失败，请稍后重试' }
+  }
+
+  return { code: 'unknown_error', message: '请求失败，请稍后重试' }
+}
+
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const normalized = normalizeApiError(error)
+    if (normalized.status === 401 && typeof window !== 'undefined') {
+      window.localStorage.removeItem(AUTH_KEY)
+      window.dispatchEvent(new CustomEvent(AUTH_EXPIRED_EVENT, { detail: normalized }))
+    }
+    return Promise.reject(new Error(normalized.message))
+  },
+)
 
 export type UserRead = {
   id: number

--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { AccountSummary } from '../components/account/AccountSummary'
 import { QuotaList } from '../components/account/QuotaList'
 import { PageContainer } from '../components/layout/PageContainer'
+import { ErrorState, LoadingState } from '../components/states/StateBlocks'
 import { useAuth } from '../contexts/auth'
 import { getCurrentUser } from '../lib/api'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
@@ -23,8 +24,8 @@ export function AccountPage() {
           <CardDescription>基础资料与下载任务额度来自后端账号接口。</CardDescription>
         </CardHeader>
         <CardContent>
-          {isLoading && <p className="state-text">账号加载中...</p>}
-          {isError && <p className="error-text">{error instanceof Error ? error.message : '账号加载失败'}</p>}
+          {isLoading && <LoadingState title="账号加载中" />}
+          {isError && <ErrorState description={error instanceof Error ? error.message : '账号加载失败'} />}
           {user && (
             <div className="account-page-grid">
               <AccountSummary user={user} />

--- a/src/pages/TaskDetailPage.tsx
+++ b/src/pages/TaskDetailPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '../lib/api'
 import { useAuth } from '../contexts/auth'
 import { PageContainer } from '../components/layout/PageContainer'
+import { ErrorState, LoadingState } from '../components/states/StateBlocks'
 import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
@@ -118,14 +119,14 @@ export function TaskDetailPage() {
   if (isLoading) {
     return (
       <PageContainer title="任务详情">
-        <p>任务加载中...</p>
+        <LoadingState title="任务加载中" />
       </PageContainer>
     )
   }
   if (isError) {
     return (
       <PageContainer title="任务详情">
-        <p className="error-text">加载失败：{error ? parseErrorMessage(error) : '未知错误'}</p>
+        <ErrorState description={`加载失败：${error ? parseErrorMessage(error) : '未知错误'}`} />
       </PageContainer>
     )
   }

--- a/src/pages/WorkbenchPage.tsx
+++ b/src/pages/WorkbenchPage.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query'
 import { listTasks, type TaskRead } from '../lib/api'
 import { useAuth } from '../contexts/auth'
 import { PageContainer } from '../components/layout/PageContainer'
+import { EmptyState, ErrorState, LoadingState } from '../components/states/StateBlocks'
 import { TaskList } from '../components/tasks/TaskList'
 import { Button } from '../components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
@@ -100,19 +101,16 @@ export function WorkbenchPage() {
             ))}
           </div>
 
-          {isLoading && <p>任务加载中...</p>}
+          {isLoading && <LoadingState title="任务加载中" />}
 
-          {!isLoading && isError && <p className="error-text">{(error as Error).message}</p>}
+          {!isLoading && isError && <ErrorState description={(error as Error).message} />}
 
           {!isLoading && tasks.length === 0 && !isError && !isReportFilter && (
-            <p className="empty-state">暂无任务，返回首页粘贴链接创建任务</p>
+            <EmptyState title="暂无任务，返回首页粘贴链接创建任务" actionLabel="返回解析页" actionTo="/" />
           )}
 
           {!isLoading && !isError && isReportFilter && visibleTasks.length === 0 && (
-            <div className="empty-state report-empty">
-              <p>暂无可导出的报告</p>
-              <Link to="/">返回解析页</Link>
-            </div>
+            <EmptyState title="暂无可导出的报告" description="已完成任务会在这里导出 PDF 报告。" actionLabel="返回解析页" actionTo="/" />
           )}
 
           <TaskList tasks={visibleTasks} />

--- a/tests/e2e/auth-to-workbench.spec.ts
+++ b/tests/e2e/auth-to-workbench.spec.ts
@@ -87,3 +87,27 @@ test('顶部报告入口跳转已完成任务筛选', async ({ page }) => {
   await expect(page.getByText('正在下载的视频')).toBeHidden()
   await expect(page.getByRole('button', { name: '已完成' })).toHaveAttribute('aria-pressed', 'true')
 })
+
+test('接口返回 401 后清理 token 并跳转登录页', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('video_web_access_token', 'expired-token')
+  })
+  await page.route('**/api/tasks*', (route) =>
+    route.fulfill({
+      status: 401,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        error: {
+          code: 'unauthorized',
+          message: '登录已失效',
+        },
+      }),
+    }),
+  )
+
+  await page.goto('/tasks')
+
+  await expect(page).toHaveURL(/\/auth/)
+  await expect(page.getByRole('heading', { name: '登录' })).toBeVisible()
+  await expect(page.evaluate(() => localStorage.getItem('video_web_access_token'))).resolves.toBeNull()
+})


### PR DESCRIPTION
## 变更摘要
- 新增 EmptyState/ErrorState/LoadingState/ForbiddenState 状态组件
- 任务页、账号页、任务详情页复用统一加载/空态/错误态
- 新增 normalizeApiError，统一处理后端 envelope、422、429、5xx、网络错误
- axios interceptor 统一处理 401：清理 token 并派发 auth expired 事件
- AuthProvider 监听登录失效事件，触发受保护路由回到 /auth

## TDD 与验证
- 红灯：状态组件、normalizeApiError、401 E2E 测试先失败
- 绿灯：实现后通过完整验证
- npm run lint
- npm test
- npm run build
- npm run test:e2e

Closes #63
Closes #64
Closes #65