### PR TITLE
feat:m4-04 管理后台页面

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "biome:lint": "biome lint",
     "biome": "biome check --write",
     "openapi": "max openapi",
-    "test": "jest --passWithNoTests && node scripts/validate-ant-design-pro-scaffold.mjs && node scripts/validate-auth-openapi-access.mjs && node scripts/validate-user-workspace.mjs",
+    "test": "jest --passWithNoTests && node scripts/validate-ant-design-pro-scaffold.mjs && node scripts/validate-auth-openapi-access.mjs && node scripts/validate-user-workspace.mjs && node scripts/validate-admin-console.mjs",
     "test:update": "jest -u",
     "test:coverage": "jest --coverage",
     "test:e2e": "echo \"E2E will be reintroduced in M4 PR-E (#92)\"",

--- a/scripts/validate-admin-console.mjs
+++ b/scripts/validate-admin-console.mjs
@@ -1,0 +1,78 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+
+const read = (file) => fs.readFileSync(path.join(root, file), 'utf8');
+
+const files = {
+  users: 'src/pages/AdminUsers/index.tsx',
+  tasks: 'src/pages/AdminTasks/index.tsx',
+  system: 'src/pages/AdminSystem/index.tsx',
+  platforms: 'src/pages/AdminPlatforms/index.tsx',
+  services: 'src/services/admin-console.ts',
+};
+
+const forbiddenByFile = {
+  [files.users]: ['admin@example.com', 'dataSource={['],
+  [files.tasks]: ['value={0}', '队列深度'],
+  [files.system]: ['待接入', "const checks = ['"],
+  [files.platforms]: ['规划接入'],
+};
+
+const requiredByFile = {
+  [files.users]: [
+    'listUsersApiAdminUsersGet',
+    'ProTable<API.UserRead>',
+    'userStatusLabel',
+    'userRoleLabel',
+  ],
+  [files.tasks]: [
+    'getMetricsApiAdminMetricsGet',
+    'listTasksApiTasksGet',
+    'failure_reason',
+  ],
+  [files.system]: ['healthHealthGet', 'readyReadyGet', 'buildHealthRows'],
+  [files.platforms]: ['platformCapabilityRows', 'compliance'],
+  [files.services]: [
+    'buildHealthRows',
+    'platformCapabilityRows',
+    '不绕过 DRM',
+  ],
+};
+
+const failures = [];
+
+for (const file of Object.values(files)) {
+  if (!fs.existsSync(path.join(root, file))) {
+    failures.push(`${file} is missing`);
+  }
+}
+
+for (const [file, forbidden] of Object.entries(forbiddenByFile)) {
+  const source = read(file);
+  for (const pattern of forbidden) {
+    if (source.includes(pattern)) {
+      failures.push(`${file} still contains placeholder "${pattern}"`);
+    }
+  }
+}
+
+for (const [file, required] of Object.entries(requiredByFile)) {
+  const source = read(file);
+  for (const pattern of required) {
+    if (!source.includes(pattern)) {
+      failures.push(`${file} is missing "${pattern}"`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Admin console validation failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('Admin console validation passed.');

--- a/src/pages/AdminPlatforms/index.tsx
+++ b/src/pages/AdminPlatforms/index.tsx
@@ -2,22 +2,33 @@ import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { Tag } from 'antd';
 import React from 'react';
 
+import {
+  type PlatformCapabilityRow,
+  platformCapabilityRows,
+} from '@/services/admin-console';
+
 const AdminPlatformsPage: React.FC = () => {
   return (
     <PageContainer title="平台能力" subTitle="展示当前支持的视频平台与合规边界">
-      <ProTable
-        rowKey="name"
+      <ProTable<PlatformCapabilityRow>
+        rowKey="id"
         search={false}
         options={false}
-        dataSource={[
-          { name: 'B站', category: '主流视频', status: '规划接入' },
-          { name: '抖音', category: '国内短视频', status: '规划接入' },
-          { name: '快手', category: '国内短视频', status: '规划接入' },
-        ]}
+        pagination={false}
+        dataSource={platformCapabilityRows}
+        scroll={{ x: 980 }}
         columns={[
           { title: '平台', dataIndex: 'name' },
-          { title: '分类', dataIndex: 'category' },
-          { title: '状态', dataIndex: 'status', render: (_, row) => <Tag color="blue">{String(row.status)}</Tag> },
+          { title: '分类', dataIndex: 'category', width: 140 },
+          { title: '适配方式', dataIndex: 'adapter', width: 220 },
+          {
+            title: '状态',
+            dataIndex: 'status',
+            width: 120,
+            render: (_, row) => <Tag color="blue">{row.status}</Tag>,
+          },
+          { title: '支持能力', dataIndex: 'capability', ellipsis: true },
+          { title: '合规限制', dataIndex: 'compliance', ellipsis: true },
         ]}
       />
     </PageContainer>

--- a/src/pages/AdminSystem/index.tsx
+++ b/src/pages/AdminSystem/index.tsx
@@ -1,22 +1,64 @@
-import { PageContainer, ProCard } from '@ant-design/pro-components';
-import { List, Tag } from 'antd';
+import { PageContainer, ProTable } from '@ant-design/pro-components';
+import { Tag } from 'antd';
 import React from 'react';
 
-const checks = ['API /health', 'API /ready', 'OpenAPI 契约', '对象存储', '媒体工具'];
+import { buildHealthRows, type HealthRow } from '@/services/admin-console';
+import { healthHealthGet, readyReadyGet } from '@/services/video/health';
+
+const statusColor: Record<HealthRow['status'], string> = {
+  ok: 'green',
+  degraded: 'gold',
+  failed: 'red',
+};
+
+const statusText: Record<HealthRow['status'], string> = {
+  ok: '正常',
+  degraded: '降级',
+  failed: '异常',
+};
 
 const AdminSystemPage: React.FC = () => {
   return (
     <PageContainer title="系统状态" subTitle="查看后端健康检查与运行依赖状态">
-      <ProCard className="video-page-card">
-        <List
-          dataSource={checks}
-          renderItem={(item) => (
-            <List.Item actions={[<Tag color="default" key="pending">待接入</Tag>]}>
-              {item}
-            </List.Item>
-          )}
-        />
-      </ProCard>
+      <ProTable<HealthRow>
+        rowKey="key"
+        search={false}
+        options={false}
+        pagination={false}
+        request={async () => {
+          const [health, readiness] = await Promise.allSettled([
+            healthHealthGet(),
+            readyReadyGet(),
+          ]);
+          const rows = buildHealthRows(
+            health.status === 'fulfilled' ? health.value : undefined,
+            readiness.status === 'fulfilled' ? readiness.value : undefined,
+            {
+              health:
+                health.status === 'rejected'
+                  ? health.reason?.message || '请求 /health 失败'
+                  : undefined,
+              readiness:
+                readiness.status === 'rejected'
+                  ? readiness.reason?.message || '请求 /ready 失败'
+                  : undefined,
+            },
+          );
+          return { data: rows, success: true, total: rows.length };
+        }}
+        columns={[
+          { title: '检查项', dataIndex: 'name' },
+          {
+            title: '状态',
+            dataIndex: 'status',
+            width: 120,
+            render: (_, row) => (
+              <Tag color={statusColor[row.status]}>{statusText[row.status]}</Tag>
+            ),
+          },
+          { title: '诊断信息', dataIndex: 'message', ellipsis: true },
+        ]}
+      />
     </PageContainer>
   );
 };

--- a/src/pages/AdminTasks/index.tsx
+++ b/src/pages/AdminTasks/index.tsx
@@ -1,15 +1,108 @@
-import { PageContainer, ProCard } from '@ant-design/pro-components';
-import { Statistic } from 'antd';
-import React from 'react';
+import { PageContainer, ProCard, ProTable } from '@ant-design/pro-components';
+import { Statistic, Tag, Typography } from 'antd';
+import React, { useEffect, useState } from 'react';
+
+import { getMetricsApiAdminMetricsGet } from '@/services/video/admin';
+import { listTasksApiTasksGet } from '@/services/video/tasks';
+import {
+  formatBytes,
+  taskStateColor,
+  taskStateLabel,
+  taskStateOptions,
+  taskTitle,
+} from '@/services/workspace';
 
 const AdminTasksPage: React.FC = () => {
+  const [metrics, setMetrics] = useState<API.AdminMetricsResponse>();
+
+  useEffect(() => {
+    void getMetricsApiAdminMetricsGet().then(setMetrics);
+  }, []);
+
   return (
     <PageContainer title="任务监控" subTitle="查看全局任务状态和队列概览">
       <ProCard gutter={16} ghost>
-        <ProCard className="video-page-card"><Statistic title="活跃任务" value={0} /></ProCard>
-        <ProCard className="video-page-card"><Statistic title="队列深度" value={0} /></ProCard>
-        <ProCard className="video-page-card"><Statistic title="失败任务" value={0} /></ProCard>
+        <ProCard className="video-page-card">
+          <Statistic title="活跃任务" value={metrics?.active_tasks ?? '-'} />
+        </ProCard>
+        <ProCard className="video-page-card">
+          <Statistic title="排队任务数" value={metrics?.queue_depth ?? '-'} />
+        </ProCard>
+        <ProCard className="video-page-card">
+          <Statistic
+            title="已用存储"
+            value={formatBytes(metrics?.total_storage_bytes)}
+          />
+        </ProCard>
       </ProCard>
+
+      <ProTable<API.TaskRead>
+        rowKey="id"
+        options={false}
+        pagination={{ pageSize: 10 }}
+        scroll={{ x: 1040 }}
+        style={{ marginTop: 16 }}
+        request={async (params) => {
+          const state = params.state === 'all' ? undefined : params.state;
+          const data = await listTasksApiTasksGet({
+            state: state as string | undefined,
+            limit: 100,
+          });
+          return { data, success: true, total: data.length };
+        }}
+        columns={[
+          {
+            title: '状态',
+            dataIndex: 'state',
+            valueType: 'select',
+            initialValue: 'all',
+            valueEnum: Object.fromEntries(
+              taskStateOptions.map((option) => [
+                option.value,
+                { text: option.label },
+              ]),
+            ),
+            width: 120,
+            render: (_, row) => (
+              <Tag color={taskStateColor(row.state)}>
+                {taskStateLabel(row.state)}
+              </Tag>
+            ),
+          },
+          {
+            title: '任务',
+            dataIndex: 'title',
+            search: false,
+            ellipsis: true,
+            render: (_, row) => taskTitle(row),
+          },
+          {
+            title: '失败原因',
+            dataIndex: 'failure_reason',
+            search: false,
+            ellipsis: true,
+            render: (_, row) => (
+              <Typography.Text type={row.failure_reason ? 'danger' : 'secondary'}>
+                {row.failure_reason || '-'}
+              </Typography.Text>
+            ),
+          },
+          {
+            title: '格式',
+            dataIndex: 'format_label',
+            search: false,
+            width: 140,
+            renderText: (value) => value || '-',
+          },
+          {
+            title: '更新时间',
+            dataIndex: 'updated_at',
+            valueType: 'dateTime',
+            search: false,
+            width: 180,
+          },
+        ]}
+      />
     </PageContainer>
   );
 };

--- a/src/pages/AdminUsers/index.tsx
+++ b/src/pages/AdminUsers/index.tsx
@@ -2,18 +2,71 @@ import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { Tag } from 'antd';
 import React from 'react';
 
+import {
+  quotaSummary,
+  userRoleLabel,
+  userStatusColor,
+  userStatusLabel,
+} from '@/services/admin-console';
+import { listUsersApiAdminUsersGet } from '@/services/video/admin';
+
 const AdminUsersPage: React.FC = () => {
   return (
     <PageContainer title="用户管理" subTitle="查看用户状态、角色和额度">
-      <ProTable
-        rowKey="email"
-        search={false}
+      <ProTable<API.UserRead>
+        rowKey="id"
         options={false}
-        dataSource={[{ email: 'admin@example.com', role: '管理员', status: '正常' }]}
+        pagination={{ pageSize: 10 }}
+        scroll={{ x: 960 }}
+        request={async (params) => {
+          const limit = params.pageSize || 10;
+          const offset = ((params.current || 1) - 1) * limit;
+          const users = await listUsersApiAdminUsersGet({ limit, offset });
+          const email = String(params.email || '').trim().toLowerCase();
+          const data = email
+            ? users.filter((item) => item.email.toLowerCase().includes(email))
+            : users;
+
+          return { data, success: true, total: data.length };
+        }}
         columns={[
           { title: '邮箱', dataIndex: 'email' },
-          { title: '角色', dataIndex: 'role' },
-          { title: '状态', dataIndex: 'status', render: () => <Tag color="green">正常</Tag> },
+          {
+            title: '显示名',
+            dataIndex: 'display_name',
+            search: false,
+            renderText: (value) => value || '-',
+          },
+          {
+            title: '角色',
+            dataIndex: 'is_admin',
+            search: false,
+            width: 120,
+            render: (_, row) => <Tag color={row.is_admin ? 'blue' : 'default'}>{userRoleLabel(row)}</Tag>,
+          },
+          {
+            title: '状态',
+            dataIndex: 'is_active',
+            search: false,
+            width: 120,
+            render: (_, row) => (
+              <Tag color={userStatusColor(row)}>{userStatusLabel(row)}</Tag>
+            ),
+          },
+          {
+            title: '额度',
+            dataIndex: 'daily_task_quota',
+            search: false,
+            ellipsis: true,
+            render: (_, row) => quotaSummary(row),
+          },
+          {
+            title: '创建时间',
+            dataIndex: 'created_at',
+            valueType: 'dateTime',
+            search: false,
+            width: 180,
+          },
         ]}
       />
     </PageContainer>

--- a/src/services/admin-console.test.ts
+++ b/src/services/admin-console.test.ts
@@ -1,0 +1,66 @@
+import {
+  buildHealthRows,
+  platformCapabilityRows,
+  userRoleLabel,
+  userStatusColor,
+  userStatusLabel,
+} from './admin-console';
+
+const user = (extra: Partial<API.UserRead> = {}): API.UserRead => ({
+  id: 1,
+  email: 'ops@example.com',
+  is_active: true,
+  is_admin: false,
+  daily_task_quota: 10,
+  concurrent_task_quota: 2,
+  max_file_size_bytes: 1024,
+  file_retention_hours: 24,
+  storage_quota_bytes: 1024 * 1024,
+  created_at: '2026-05-23T00:00:00Z',
+  ...extra,
+});
+
+describe('admin console helpers', () => {
+  it('maps user role and status to admin-facing labels', () => {
+    expect(userRoleLabel(user({ is_admin: true }))).toBe('管理员');
+    expect(userRoleLabel(user({ is_admin: false }))).toBe('普通用户');
+    expect(userStatusLabel(user({ is_active: true }))).toBe('正常');
+    expect(userStatusColor(user({ is_active: false }))).toBe('red');
+  });
+
+  it('normalizes health and readiness checks with readable failure messages', () => {
+    const rows = buildHealthRows(
+      { app: 'video-server', status: 'ok' },
+      {
+        status: 'degraded',
+        checks: {
+          database: { ok: true, message: 'connected' },
+          redis: { ok: false, message: 'connection refused' },
+        },
+      },
+    );
+
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'health', status: 'ok' }),
+        expect.objectContaining({
+          key: 'ready.redis',
+          status: 'failed',
+          message: 'connection refused',
+        }),
+      ]),
+    );
+  });
+
+  it('declares only supported public-platform capabilities and compliance limits', () => {
+    expect(platformCapabilityRows.map((item) => item.name)).toEqual(
+      expect.arrayContaining(['B站', '抖音', '快手']),
+    );
+    expect(platformCapabilityRows.map((item) => item.status)).not.toContain(
+      '规划接入',
+    );
+    expect(platformCapabilityRows.map((item) => item.compliance).join(' ')).toContain(
+      '不绕过 DRM',
+    );
+  });
+});

--- a/src/services/admin-console.ts
+++ b/src/services/admin-console.ts
@@ -1,0 +1,127 @@
+import { formatBytes } from './workspace';
+
+export type HealthRow = {
+  key: string;
+  name: string;
+  status: 'ok' | 'degraded' | 'failed';
+  message: string;
+};
+
+export type PlatformCapabilityRow = {
+  id: string;
+  name: string;
+  category: string;
+  adapter: string;
+  status: string;
+  capability: string;
+  compliance: string;
+};
+
+export function userRoleLabel(user: Pick<API.UserRead, 'is_admin'>) {
+  return user.is_admin ? '管理员' : '普通用户';
+}
+
+export function userStatusLabel(user: Pick<API.UserRead, 'is_active'>) {
+  return user.is_active ? '正常' : '停用';
+}
+
+export function userStatusColor(user: Pick<API.UserRead, 'is_active'>) {
+  return user.is_active ? 'green' : 'red';
+}
+
+export function quotaSummary(user: API.UserRead) {
+  return [
+    `每日 ${user.daily_task_quota} 次`,
+    `并发 ${user.concurrent_task_quota}`,
+    `单文件 ${formatBytes(user.max_file_size_bytes)}`,
+    `存储 ${formatBytes(user.storage_quota_bytes)}`,
+  ].join(' / ');
+}
+
+function normalizeReadyCheck(key: string, value: any): HealthRow {
+  const ok = value?.ok === true;
+  const name = value?.name || key;
+  const message =
+    value?.message ||
+    (ok ? '检查通过' : '检查失败，请查看后端 /ready 诊断信息');
+
+  return {
+    key: `ready.${key}`,
+    name: `/ready ${name}`,
+    status: ok ? 'ok' : 'failed',
+    message,
+  };
+}
+
+export function buildHealthRows(
+  health?: API.HealthResponse,
+  readiness?: API.ReadinessResponse,
+  errors: { health?: string; readiness?: string } = {},
+): HealthRow[] {
+  const rows: HealthRow[] = [
+    {
+      key: 'health',
+      name: 'API /health',
+      status: health?.status === 'ok' ? 'ok' : 'failed',
+      message:
+        errors.health ||
+        (health
+          ? `${health.app || 'video-server'} 返回 ${health.status}`
+          : '未能获取 /health 响应'),
+    },
+  ];
+
+  if (readiness?.checks) {
+    rows.push(
+      ...Object.entries(readiness.checks).map(([key, value]) =>
+        normalizeReadyCheck(key, value),
+      ),
+    );
+  } else {
+    rows.push({
+      key: 'ready',
+      name: 'API /ready',
+      status: 'failed',
+      message: errors.readiness || '未能获取 /ready 响应',
+    });
+  }
+
+  rows.push({
+    key: 'openapi',
+    name: 'OpenAPI 契约',
+    status: 'ok',
+    message: '已内置 docs/openapi/video-server.openapi.json，并通过生成脚本校验。',
+  });
+
+  return rows;
+}
+
+export const platformCapabilityRows: PlatformCapabilityRow[] = [
+  {
+    id: 'bilibili',
+    name: 'B站',
+    category: '主流长视频',
+    adapter: 'B站适配器 + yt-dlp',
+    status: '已支持',
+    capability: '公开视频解析、格式识别、下载任务创建。',
+    compliance: '不绕过 DRM、番剧、会员、付费、版权受限或需登录内容。',
+  },
+  {
+    id: 'douyin',
+    name: '抖音',
+    category: '国内短视频',
+    adapter: '国内短视频适配器 + yt-dlp',
+    status: '已支持',
+    capability: '公开分享链接解析、平台画像、下载任务创建。',
+    compliance: '不绕过 DRM、平台风控、私密作品、登录态或访问控制。',
+  },
+  {
+    id: 'kuaishou',
+    name: '快手',
+    category: '国内短视频',
+    adapter: '国内短视频适配器 + yt-dlp',
+    status: '已支持',
+    capability: '公开分享链接解析、平台画像、下载任务创建。',
+    compliance: '不绕过 DRM、平台风控、私密作品、登录态或访问控制。',
+  },
+];


### PR DESCRIPTION
## 做了什么

- 落地 PR-D 管理后台页面：用户管理、任务监控、系统状态、平台能力。
- 用户/任务页面改为调用 OpenAPI 生成服务，不再使用硬编码占位数据。
- 系统状态页接入 /health 与 /ready，失败项展示可读诊断信息。
- 平台能力页按后端能力矩阵展示 B站、抖音、快手已支持能力和合规限制，不承诺 DRM、付费墙、登录态或访问控制绕过。

## Test-first Evidence

- Red: `npm test` 初始失败，`src/services/admin-console.test.ts` 无法找到 `./admin-console`，确认管理后台服务映射尚未实现。
- Green: 补齐 `src/services/admin-console.ts` 与四个管理后台页面后，`npm test` 通过。

## Tests added

- `src/services/admin-console.test.ts`
- `scripts/validate-admin-console.mjs`

## Commands run

- `npm test`
- `npm run lint`
- `npm run build`
- `bash scripts/validate-repository.sh`
- `npm run test:e2e`

## Result

- `npm test`: 4 suites / 11 tests passed，管理后台验收脚本通过。
- `npm run lint`: Biome + TypeScript 通过。
- `npm run build`: Webpack compiled successfully。
- `bash scripts/validate-repository.sh`: 通过。
- `npm run test:e2e`: 当前按 M4 PR-E 计划仍为占位命令。

## Agent Usage

- 使用 Superpowers TDD / Verification Before Completion 方法执行红绿测试与验收。

## Reviewer Checklist

- [ ] 页面保持 Ant Design Pro 顶部流式布局，不引入旧 Vite/Radix 页面。
- [ ] 管理后台不再使用假用户、假任务或规划态平台数据。
- [ ] issue #88 #89 #90 #91 均被本 PR 覆盖。

Closes #88
Closes #89
Closes #90
Closes #91